### PR TITLE
Problem: inconsistent code style (fix #21)

### DIFF
--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -16,12 +16,10 @@ class UserWalletConnectCallback : public WalletConnectCallback {
 public:
   UserWalletConnectCallback() {}
   virtual ~UserWalletConnectCallback() {}
-  void onConnected(const WalletConnectSessionInfo& sessioninfo) const;
-  void
-  onDisconnected(const WalletConnectSessionInfo& sessioninfo) const;
-  void
-  onConnecting(const WalletConnectSessionInfo& sessioninfo) const;
-  void onUpdated(const WalletConnectSessionInfo& sessioninfo) const;
+  void onConnected(const WalletConnectSessionInfo &sessioninfo) const;
+  void onDisconnected(const WalletConnectSessionInfo &sessioninfo) const;
+  void onConnecting(const WalletConnectSessionInfo &sessioninfo) const;
+  void onUpdated(const WalletConnectSessionInfo &sessioninfo) const;
 };
 
 APlayCppSdkActor *APlayCppSdkActor::getInstance() { return _sdk; }
@@ -354,7 +352,7 @@ void APlayCppSdkActor::sendEvent(const FWalletConnectSessionInfo &info) {
 }
 
 void UserWalletConnectCallback::onConnected(
-    const WalletConnectSessionInfo& sessioninfo) const {
+    const WalletConnectSessionInfo &sessioninfo) const {
   UE_LOG(LogTemp, Log, TEXT("user c++ onConnected"));
   if (APlayCppSdkActor::getInstance()) {
     FWalletConnectSessionInfo output;
@@ -364,7 +362,7 @@ void UserWalletConnectCallback::onConnected(
   }
 }
 void UserWalletConnectCallback::onDisconnected(
-    const WalletConnectSessionInfo& sessioninfo) const {
+    const WalletConnectSessionInfo &sessioninfo) const {
   UE_LOG(LogTemp, Log, TEXT("user c++ onDisconnected"));
   if (APlayCppSdkActor::getInstance()) {
     FWalletConnectSessionInfo output;
@@ -375,7 +373,7 @@ void UserWalletConnectCallback::onDisconnected(
   }
 }
 void UserWalletConnectCallback::onConnecting(
-    const WalletConnectSessionInfo& sessioninfo) const {
+    const WalletConnectSessionInfo &sessioninfo) const {
   UE_LOG(LogTemp, Log, TEXT("user c++ onConnecting"));
   if (APlayCppSdkActor::getInstance()) {
     FWalletConnectSessionInfo output;
@@ -386,7 +384,7 @@ void UserWalletConnectCallback::onConnecting(
   }
 }
 void UserWalletConnectCallback::onUpdated(
-    const WalletConnectSessionInfo& sessioninfo) const {
+    const WalletConnectSessionInfo &sessioninfo) const {
 
   UE_LOG(LogTemp, Log, TEXT("user c++ onUpdated"));
   if (APlayCppSdkActor::getInstance()) {

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/TxBuilder.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/TxBuilder.h
@@ -3,28 +3,28 @@
 #include "cronosplay/include/defi-wallet-core-cpp/src/lib.rs.h"
 #include <stdio.h>
 
-
 class TxBuilder {
 public:
-    virtual void setData()=0;
-    virtual  org::defi_wallet_core::CosmosSDKTxInfoRaw getTxInfo()=0;
+  virtual void setData() = 0;
+  virtual org::defi_wallet_core::CosmosSDKTxInfoRaw getTxInfo() = 0;
 };
 
 // top manager
 class TxDirector {
-    TxBuilder* builder;
+  TxBuilder *builder;
+
 public:
-    void setBuilder(TxBuilder* newbuilder);
-    org::defi_wallet_core::CosmosSDKTxInfoRaw makeTx();
+  void setBuilder(TxBuilder *newbuilder);
+  org::defi_wallet_core::CosmosSDKTxInfoRaw makeTx();
 };
 
 // various txs
 class CosmosSendAmountTxBuilder : public TxBuilder {
 public:
-    org::defi_wallet_core::CosmosSDKTxInfoRaw info;
-    void setData();
-    
-    org::defi_wallet_core::CosmosSDKTxInfoRaw getTxInfo();
+  org::defi_wallet_core::CosmosSDKTxInfoRaw info;
+  void setData();
+
+  org::defi_wallet_core::CosmosSDKTxInfoRaw getTxInfo();
 };
 
 #endif /* TxBuilder_hpp */

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/contract.rs.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/contract.rs.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "lib.rs.h"
 #include "uint.rs.h"
@@ -23,23 +23,19 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
 class Opaque;
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -111,11 +107,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -165,8 +159,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -202,13 +195,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -217,49 +208,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -392,8 +375,7 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
@@ -407,8 +389,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -440,8 +421,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -469,38 +449,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -508,13 +480,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -525,65 +495,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -598,18 +558,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -633,8 +588,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -679,10 +633,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -721,27 +673,17 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
 namespace detail {
-template <typename... Ts>
-struct make_void {
-  using type = void;
-};
+template <typename... Ts> struct make_void { using type = void; };
 
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 template <typename Void, template <typename...> class, typename...>
 struct detect : std::false_type {};
@@ -751,8 +693,7 @@ struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
 template <template <typename...> class T, typename... A>
 using is_detected = detect<void, T, A...>;
 
-template <typename T>
-using detect_IsRelocatable = typename T::IsRelocatable;
+template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
 
 template <typename T>
 struct get_IsRelocatable
@@ -770,8 +711,7 @@ struct IsRelocatable
 #endif // CXXBRIDGE1_RELOCATABLE
 
 namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
+template <typename T, typename = void *> struct operator_new {
   void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
@@ -781,15 +721,13 @@ struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
 };
 } // namespace detail
 
-template <typename T>
-union ManuallyDrop {
+template <typename T> union ManuallyDrop {
   T value;
   ManuallyDrop(T &&value) : value(::std::move(value)) {}
   ~ManuallyDrop() {}
 };
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit {
   T value;
   void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
   MaybeUninit() {}
@@ -804,8 +742,7 @@ struct PtrLen final {
 };
 } // namespace repr
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final {
 public:
   static Error error(repr::PtrLen repr) noexcept {
     Error error;
@@ -819,12 +756,12 @@ public:
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct Erc20;
-    struct Erc721;
-    struct Erc1155;
-  }
-}
+namespace defi_wallet_core {
+struct Erc20;
+struct Erc721;
+struct Erc1155;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -846,7 +783,8 @@ struct Erc20 final {
   /// U256 = erc20.balance_of("0xf0307093f23311FE6776a7742dB619EB3df62969");
   /// cout << balance.to_string() << endl;
   /// ```
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address) const;
+  ::org::defi_wallet_core::U256
+  balance_of(::rust::String account_address) const;
 
   /// Returns the name of the token
   /// ```
@@ -884,13 +822,15 @@ struct Erc20 final {
   /// ```
   ::org::defi_wallet_core::Erc20 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
   /// ```
   /// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
   ///    "https://cronos-testnet-3.crypto.org:8545", 383);
   /// erc20 = erc20.interval(3000);
   /// ```
-  ::org::defi_wallet_core::Erc20 interval(::std::uint64_t polling_interval_ms) noexcept;
+  ::org::defi_wallet_core::Erc20
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
   /// Moves `amount` tokens from the caller’s account to `to_address`.
   /// # Transfer 100 tokens (devnet)
@@ -916,10 +856,13 @@ struct Erc20 final {
   ///                 .legacy();
   /// erc20.transfer(signer2_address, "100", *privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer(::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer(::rust::String to_address, ::rust::String amount,
+           const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Moves `amount` tokens from `from_address` to `to_address` using the allowance mechanism.
-  /// # Transfer from signer1 to validator1 using the allowance mechanism (devnet)
+  /// Moves `amount` tokens from `from_address` to `to_address` using the
+  /// allowance mechanism. # Transfer from signer1 to validator1 using the
+  /// allowance mechanism (devnet)
   /// ```
   /// String mycronosrpc = getEnv("MYCRONOSRPC");
   /// char hdpath[100];
@@ -943,10 +886,13 @@ struct Erc20 final {
   /// erc20.transfer_from(signer1_address, validator1_address, "100",
   ///                 *signer2_privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer_from(::rust::String from_address, ::rust::String to_address,
+                ::rust::String amount,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Allows `approved_address` to withdraw from your account multiple times, up to the
-  /// `amount` amount.
+  /// Allows `approved_address` to withdraw from your account multiple times, up
+  /// to the `amount` amount.
   /// ## approves 1000 allowance (devnet)
   /// ```
   /// String mycronosrpc = getEnv("MYCRONOSRPC");
@@ -968,11 +914,15 @@ struct Erc20 final {
   /// Erc20 erc20 = new_erc20("0x5003c1fcc043D2d81fF970266bf3fa6e8C5a1F3A",
   ///                         mycronosrpc, chainid)
   ///                 .legacy();
-  /// erc20.interval(3000).approve(signer2_address, "1000", *signer1_privatekey);
+  /// erc20.interval(3000).approve(signer2_address, "1000",
+  /// *signer1_privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw approve(::rust::String approved_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  approve(::rust::String approved_address, ::rust::String amount,
+          const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+  /// Returns the amount which `spender` is still allowed to withdraw from
+  /// `owner`.
   /// ```
   /// Erc20 erc20 = new_erc20("0x5003c1fcc043D2d81fF970266bf3fa6e8C5a1F3A",
   ///                         mycronosrpc, chainid)
@@ -1004,7 +954,8 @@ struct Erc721 final {
   ::std::uint64_t chain_id;
 
   /// Returns the number of tokens in owner's `account_address`.
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address) const;
+  ::org::defi_wallet_core::U256
+  balance_of(::rust::String account_address) const;
 
   /// Returns the owner of the `token_id` token.
   ::rust::String owner_of(::rust::String token_id) const;
@@ -1021,50 +972,69 @@ struct Erc721 final {
   /// Makes a legacy transaction instead of an EIP-1559 one
   ::org::defi_wallet_core::Erc721 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
-  ::org::defi_wallet_core::Erc721 interval(::std::uint64_t polling_interval_ms) noexcept;
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
+  ::org::defi_wallet_core::Erc721
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
   /// Transfers `token_id` token from `from_address` to `to_address`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer_from(::rust::String from_address, ::rust::String to_address,
+                ::rust::String token_id,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Safely transfers `token_id` token from `from_address` to `to_address`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Safely transfers `token_id` token from `from_address` to `to_address` with
   /// `additional_data`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from_with_data(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  safe_transfer_from_with_data(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Gives permission to `approved_address` to transfer `token_id` token to another account.
-  /// The approval is cleared when the token is transferred. Only a single account can be
-  /// approved at a time, so approving the zero address clears previous approvals.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw approve(::rust::String approved_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Gives permission to `approved_address` to transfer `token_id` token to
+  /// another account. The approval is cleared when the token is transferred.
+  /// Only a single account can be approved at a time, so approving the zero
+  /// address clears previous approvals.
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  approve(::rust::String approved_address, ::rust::String token_id,
+          const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Enable or disable approval for a third party `approved_address` to manage all of
-  /// sender's assets
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Enable or disable approval for a third party `approved_address` to manage
+  /// all of sender's assets
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(
+      ::rust::String approved_address, bool approved,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Get the approved address for a single NFT by `token_id`
   ::rust::String get_approved(::rust::String token_id) const;
 
   /// Query if an address is an authorized `approved_address` for `owner`
-  bool is_approved_for_all(::rust::String owner, ::rust::String approved_address) const;
+  bool is_approved_for_all(::rust::String owner,
+                           ::rust::String approved_address) const;
 
   /// Returns the total amount of tokens stored by the contract.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
   ::org::defi_wallet_core::U256 total_supply() const;
 
-  /// Returns a token ID at a given index of all the tokens stored by the contract. Use along
-  /// with totalSupply to enumerate all tokens.
+  /// Returns a token ID at a given index of all the tokens stored by the
+  /// contract. Use along with totalSupply to enumerate all tokens.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
   ::rust::String token_by_index(::rust::String index) const;
 
-  /// Returns a token ID owned by owner at a given index of its token list. Use along with
-  /// balanceOf to enumerate all of owner's tokens.
+  /// Returns a token ID owned by owner at a given index of its token list. Use
+  /// along with balanceOf to enumerate all of owner's tokens.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
-  ::rust::String token_of_owner_by_index(::rust::String owner, ::rust::String index) const;
+  ::rust::String token_of_owner_by_index(::rust::String owner,
+                                         ::rust::String index) const;
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1080,11 +1050,14 @@ struct Erc1155 final {
   ::std::uint64_t chain_id;
 
   /// Returns the amount of tokens of `token_id` owned by `account_address`.
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address, ::rust::String token_id) const;
+  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address,
+                                           ::rust::String token_id) const;
 
   /// Batched version of balance_of.
   /// Get the balance of multiple account/token pairs
-  ::rust::Vec<::rust::String> balance_of_batch(::rust::Vec<::rust::String> account_addresses, ::rust::Vec<::rust::String> token_ids) const;
+  ::rust::Vec<::rust::String>
+  balance_of_batch(::rust::Vec<::rust::String> account_addresses,
+                   ::rust::Vec<::rust::String> token_ids) const;
 
   /// Get distinct Uniform Resource Identifier (URI) for a given token
   ::rust::String uri(::rust::String token_id) const;
@@ -1092,22 +1065,36 @@ struct Erc1155 final {
   /// Makes a legacy transaction instead of an EIP-1559 one
   ::org::defi_wallet_core::Erc1155 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
-  ::org::defi_wallet_core::Erc1155 interval(::std::uint64_t polling_interval_ms) noexcept;
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
+  ::org::defi_wallet_core::Erc1155
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
-  /// Transfers `amount` tokens of `token_id` from `from_address` to `to_address` with
-  /// `additional_data`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::String amount, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Transfers `amount` tokens of `token_id` from `from_address` to
+  /// `to_address` with `additional_data`.
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id, ::rust::String amount,
+      ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Batched version of safeTransferFrom.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_batch_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::Vec<::rust::String> token_ids, ::rust::Vec<::rust::String> amounts, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_batch_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::Vec<::rust::String> token_ids,
+      ::rust::Vec<::rust::String> amounts,
+      ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Enable or disable approval for a third party `approved_address` to manage all of
-  /// sender's assets
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Enable or disable approval for a third party `approved_address` to manage
+  /// all of sender's assets
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(
+      ::rust::String approved_address, bool approved,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Query if an address is an authorized `approved_address` for `owner`
-  bool is_approved_for_all(::rust::String owner, ::rust::String approved_address) const;
+  bool is_approved_for_all(::rust::String owner,
+                           ::rust::String approved_address) const;
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1116,110 +1103,238 @@ struct Erc1155 final {
 } // namespace org
 
 static_assert(
-    ::rust::IsRelocatable<::org::defi_wallet_core::CronosTransactionReceiptRaw>::value,
-    "type org::defi_wallet_core::CronosTransactionReceiptRaw should be trivially move constructible and trivially destructible in C++ to be used as a return value of `transfer`, `transfer_from`, `approve` in Rust");
-static_assert(
-    ::rust::IsRelocatable<::org::defi_wallet_core::U256>::value,
-    "type org::defi_wallet_core::U256 should be trivially move constructible and trivially destructible in C++ to be used as a return value of `balance_of`, `total_supply` in Rust");
+    ::rust::IsRelocatable<
+        ::org::defi_wallet_core::CronosTransactionReceiptRaw>::value,
+    "type org::defi_wallet_core::CronosTransactionReceiptRaw should be "
+    "trivially move constructible and trivially destructible in C++ to be used "
+    "as a return value of `transfer`, `transfer_from`, `approve` in Rust");
+static_assert(::rust::IsRelocatable<::org::defi_wallet_core::U256>::value,
+              "type org::defi_wallet_core::U256 should be trivially move "
+              "constructible and trivially destructible in C++ to be used as a "
+              "return value of `balance_of`, `total_supply` in Rust");
 
 namespace org {
 namespace defi_wallet_core {
 extern "C" {
-void org$defi_wallet_core$cxxbridge1$new_erc20(::rust::String *address, ::rust::String *web3api_url, ::std::uint64_t chian_id, ::org::defi_wallet_core::Erc20 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$new_erc20(
+    ::rust::String *address, ::rust::String *web3api_url,
+    ::std::uint64_t chian_id, ::org::defi_wallet_core::Erc20 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$balance_of(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *account_address, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$balance_of(
+    const ::org::defi_wallet_core::Erc20 &self, ::rust::String *account_address,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$name(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$name(
+    const ::org::defi_wallet_core::Erc20 &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$symbol(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$symbol(
+    const ::org::defi_wallet_core::Erc20 &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$decimals(const ::org::defi_wallet_core::Erc20 &self, ::std::uint8_t *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$decimals(
+    const ::org::defi_wallet_core::Erc20 &self,
+    ::std::uint8_t *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc20$legacy(::org::defi_wallet_core::Erc20 &self, ::org::defi_wallet_core::Erc20 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc20$legacy(
+    ::org::defi_wallet_core::Erc20 &self,
+    ::org::defi_wallet_core::Erc20 *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc20$interval(::org::defi_wallet_core::Erc20 &self, ::std::uint64_t polling_interval_ms, ::org::defi_wallet_core::Erc20 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc20$interval(
+    ::org::defi_wallet_core::Erc20 &self, ::std::uint64_t polling_interval_ms,
+    ::org::defi_wallet_core::Erc20 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$transfer(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *to_address, ::rust::String *amount, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$transfer(
+    const ::org::defi_wallet_core::Erc20 &self, ::rust::String *to_address,
+    ::rust::String *amount,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$transfer_from(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::String *amount, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$transfer_from(
+    const ::org::defi_wallet_core::Erc20 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::String *amount,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$approve(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *approved_address, ::rust::String *amount, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$approve(
+    const ::org::defi_wallet_core::Erc20 &self,
+    ::rust::String *approved_address, ::rust::String *amount,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$allowance(const ::org::defi_wallet_core::Erc20 &self, ::rust::String *owner, ::rust::String *spender, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$allowance(
+    const ::org::defi_wallet_core::Erc20 &self, ::rust::String *owner,
+    ::rust::String *spender, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$total_supply(const ::org::defi_wallet_core::Erc20 &self, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc20$total_supply(
+    const ::org::defi_wallet_core::Erc20 &self,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$new_erc721(::rust::String *address, ::rust::String *web3api_url, ::std::uint64_t chian_id, ::org::defi_wallet_core::Erc721 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$new_erc721(
+    ::rust::String *address, ::rust::String *web3api_url,
+    ::std::uint64_t chian_id,
+    ::org::defi_wallet_core::Erc721 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$balance_of(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *account_address, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$balance_of(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::rust::String *account_address,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$owner_of(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$owner_of(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$name(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$name(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$symbol(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$symbol(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$token_uri(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$token_uri(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id,
+    ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc721$legacy(::org::defi_wallet_core::Erc721 &self, ::org::defi_wallet_core::Erc721 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc721$legacy(
+    ::org::defi_wallet_core::Erc721 &self,
+    ::org::defi_wallet_core::Erc721 *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc721$interval(::org::defi_wallet_core::Erc721 &self, ::std::uint64_t polling_interval_ms, ::org::defi_wallet_core::Erc721 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc721$interval(
+    ::org::defi_wallet_core::Erc721 &self, ::std::uint64_t polling_interval_ms,
+    ::org::defi_wallet_core::Erc721 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$transfer_from(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::String *token_id, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$transfer_from(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::String *token_id,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::String *token_id, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::String *token_id,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from_with_data(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::String *token_id, ::rust::Vec<::std::uint8_t> *additional_data, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from_with_data(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::String *token_id,
+    ::rust::Vec<::std::uint8_t> *additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$approve(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *approved_address, ::rust::String *token_id, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$approve(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::rust::String *approved_address, ::rust::String *token_id,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$set_approval_for_all(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc721$set_approval_for_all(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::rust::String *approved_address, bool approved,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$get_approved(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$get_approved(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *token_id,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$is_approved_for_all(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *owner, ::rust::String *approved_address, bool *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$is_approved_for_all(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *owner,
+    ::rust::String *approved_address, bool *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$total_supply(const ::org::defi_wallet_core::Erc721 &self, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$total_supply(
+    const ::org::defi_wallet_core::Erc721 &self,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$token_by_index(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *index, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$token_by_index(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *index,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc721$token_of_owner_by_index(const ::org::defi_wallet_core::Erc721 &self, ::rust::String *owner, ::rust::String *index, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc721$token_of_owner_by_index(
+    const ::org::defi_wallet_core::Erc721 &self, ::rust::String *owner,
+    ::rust::String *index, ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$new_erc1155(::rust::String *address, ::rust::String *web3api_url, ::std::uint64_t chian_id, ::org::defi_wallet_core::Erc1155 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$new_erc1155(
+    ::rust::String *address, ::rust::String *web3api_url,
+    ::std::uint64_t chian_id,
+    ::org::defi_wallet_core::Erc1155 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$balance_of(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *account_address, ::rust::String *token_id, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$balance_of(
+    const ::org::defi_wallet_core::Erc1155 &self,
+    ::rust::String *account_address, ::rust::String *token_id,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$balance_of_batch(const ::org::defi_wallet_core::Erc1155 &self, ::rust::Vec<::rust::String> *account_addresses, ::rust::Vec<::rust::String> *token_ids, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$balance_of_batch(
+    const ::org::defi_wallet_core::Erc1155 &self,
+    ::rust::Vec<::rust::String> *account_addresses,
+    ::rust::Vec<::rust::String> *token_ids,
+    ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$uri(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *token_id, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$uri(
+    const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *token_id,
+    ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc1155$legacy(::org::defi_wallet_core::Erc1155 &self, ::org::defi_wallet_core::Erc1155 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc1155$legacy(
+    ::org::defi_wallet_core::Erc1155 &self,
+    ::org::defi_wallet_core::Erc1155 *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::Erc1155 &self, ::std::uint64_t polling_interval_ms, ::org::defi_wallet_core::Erc1155 *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Erc1155$interval(
+    ::org::defi_wallet_core::Erc1155 &self, ::std::uint64_t polling_interval_ms,
+    ::org::defi_wallet_core::Erc1155 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$safe_transfer_from(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::String *token_id, ::rust::String *amount, ::rust::Vec<::std::uint8_t> *additional_data, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$safe_transfer_from(
+    const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::String *token_id,
+    ::rust::String *amount, ::rust::Vec<::std::uint8_t> *additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$safe_batch_transfer_from(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *from_address, ::rust::String *to_address, ::rust::Vec<::rust::String> *token_ids, ::rust::Vec<::rust::String> *amounts, ::rust::Vec<::std::uint8_t> *additional_data, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc1155$safe_batch_transfer_from(
+    const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *from_address,
+    ::rust::String *to_address, ::rust::Vec<::rust::String> *token_ids,
+    ::rust::Vec<::rust::String> *amounts,
+    ::rust::Vec<::std::uint8_t> *additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$set_approval_for_all(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc1155$set_approval_for_all(
+    const ::org::defi_wallet_core::Erc1155 &self,
+    ::rust::String *approved_address, bool approved,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Erc1155$is_approved_for_all(const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *owner, ::rust::String *approved_address, bool *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$Erc1155$is_approved_for_all(
+    const ::org::defi_wallet_core::Erc1155 &self, ::rust::String *owner,
+    ::rust::String *approved_address, bool *return$) noexcept;
 } // extern "C"
 
-  /// Construct an Erc20 struct
-  /// ```
-  /// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
-  ///    "https://cronos-testnet-3.crypto.org:8545", 383);
-  /// ```
-::org::defi_wallet_core::Erc20 new_erc20(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept {
+/// Construct an Erc20 struct
+/// ```
+/// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
+///    "https://cronos-testnet-3.crypto.org:8545", 383);
+/// ```
+::org::defi_wallet_core::Erc20 new_erc20(::rust::String address,
+                                         ::rust::String web3api_url,
+                                         ::std::uint64_t chian_id) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc20> return$;
-  org$defi_wallet_core$cxxbridge1$new_erc20(&address, &web3api_url, chian_id, &return$.value);
+  org$defi_wallet_core$cxxbridge1$new_erc20(&address, &web3api_url, chian_id,
+                                            &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 Erc20::balance_of(::rust::String account_address) const {
+::org::defi_wallet_core::U256
+Erc20::balance_of(::rust::String account_address) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$balance_of(*this, &account_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$balance_of(*this, &account_address,
+                                                       &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1228,7 +1343,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc20::name() const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$name(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$name(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1237,7 +1353,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc20::symbol() const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$symbol(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$symbol(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1246,7 +1363,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::std::uint8_t Erc20::decimals() const {
   ::rust::MaybeUninit<::std::uint8_t> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$decimals(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$decimals(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1259,42 +1377,61 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Erc20 Erc20::interval(::std::uint64_t polling_interval_ms) noexcept {
+::org::defi_wallet_core::Erc20
+Erc20::interval(::std::uint64_t polling_interval_ms) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc20> return$;
-  org$defi_wallet_core$cxxbridge1$Erc20$interval(*this, polling_interval_ms, &return$.value);
+  org$defi_wallet_core$cxxbridge1$Erc20$interval(*this, polling_interval_ms,
+                                                 &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc20::transfer(::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$transfer(*this, &to_address, &amount, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc20::transfer(::rust::String to_address, ::rust::String amount,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$transfer(
+      *this, &to_address, &amount, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc20::transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$transfer_from(*this, &from_address, &to_address, &amount, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw Erc20::transfer_from(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::String amount,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$transfer_from(
+          *this, &from_address, &to_address, &amount, private_key,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc20::approve(::rust::String approved_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$approve(*this, &approved_address, &amount, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc20::approve(::rust::String approved_address, ::rust::String amount,
+               const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$approve(
+      *this, &approved_address, &amount, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::String Erc20::allowance(::rust::String owner, ::rust::String spender) const {
+::rust::String Erc20::allowance(::rust::String owner,
+                                ::rust::String spender) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$allowance(*this, &owner, &spender, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$allowance(
+      *this, &owner, &spender, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1303,23 +1440,30 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::org::defi_wallet_core::U256 Erc20::total_supply() const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc20$total_supply(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc20$total_supply(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Construct an Erc721 struct
-::org::defi_wallet_core::Erc721 new_erc721(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept {
+/// Construct an Erc721 struct
+::org::defi_wallet_core::Erc721 new_erc721(::rust::String address,
+                                           ::rust::String web3api_url,
+                                           ::std::uint64_t chian_id) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc721> return$;
-  org$defi_wallet_core$cxxbridge1$new_erc721(&address, &web3api_url, chian_id, &return$.value);
+  org$defi_wallet_core$cxxbridge1$new_erc721(&address, &web3api_url, chian_id,
+                                             &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 Erc721::balance_of(::rust::String account_address) const {
+::org::defi_wallet_core::U256
+Erc721::balance_of(::rust::String account_address) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$balance_of(*this, &account_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$balance_of(*this, &account_address,
+                                                        &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1328,7 +1472,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc721::owner_of(::rust::String token_id) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$owner_of(*this, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$owner_of(
+      *this, &token_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1337,7 +1482,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc721::name() const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$name(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$name(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1346,7 +1492,8 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc721::symbol() const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$symbol(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$symbol(*this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1355,7 +1502,9 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc721::token_uri(::rust::String token_id) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$token_uri(*this, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$token_uri(*this, &token_id,
+                                                       &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1368,52 +1517,87 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Erc721 Erc721::interval(::std::uint64_t polling_interval_ms) noexcept {
+::org::defi_wallet_core::Erc721
+Erc721::interval(::std::uint64_t polling_interval_ms) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc721> return$;
-  org$defi_wallet_core$cxxbridge1$Erc721$interval(*this, polling_interval_ms, &return$.value);
+  org$defi_wallet_core$cxxbridge1$Erc721$interval(*this, polling_interval_ms,
+                                                  &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$transfer_from(*this, &from_address, &to_address, &token_id, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::transfer_from(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::String token_id,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$transfer_from(
+          *this, &from_address, &to_address, &token_id, private_key,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from(*this, &from_address, &to_address, &token_id, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::safe_transfer_from(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::String token_id,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from(
+          *this, &from_address, &to_address, &token_id, private_key,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::safe_transfer_from_with_data(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(::std::move(additional_data));
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from_with_data(*this, &from_address, &to_address, &token_id, &additional_data$.value, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc721::safe_transfer_from_with_data(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(
+      ::std::move(additional_data));
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$safe_transfer_from_with_data(
+          *this, &from_address, &to_address, &token_id, &additional_data$.value,
+          private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::approve(::rust::String approved_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$approve(*this, &approved_address, &token_id, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc721::approve(::rust::String approved_address, ::rust::String token_id,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$approve(
+      *this, &approved_address, &token_id, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc721::set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$set_approval_for_all(*this, &approved_address, approved, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc721::set_approval_for_all(
+    ::rust::String approved_address, bool approved,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$set_approval_for_all(
+          *this, &approved_address, approved, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1422,16 +1606,21 @@ void org$defi_wallet_core$cxxbridge1$Erc1155$interval(::org::defi_wallet_core::E
 
 ::rust::String Erc721::get_approved(::rust::String token_id) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$get_approved(*this, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$get_approved(*this, &token_id,
+                                                          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-bool Erc721::is_approved_for_all(::rust::String owner, ::rust::String approved_address) const {
+bool Erc721::is_approved_for_all(::rust::String owner,
+                                 ::rust::String approved_address) const {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$is_approved_for_all(*this, &owner, &approved_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$is_approved_for_all(
+          *this, &owner, &approved_address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1440,7 +1629,9 @@ bool Erc721::is_approved_for_all(::rust::String owner, ::rust::String approved_a
 
 ::org::defi_wallet_core::U256 Erc721::total_supply() const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$total_supply(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$total_supply(*this,
+                                                          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1449,43 +1640,61 @@ bool Erc721::is_approved_for_all(::rust::String owner, ::rust::String approved_a
 
 ::rust::String Erc721::token_by_index(::rust::String index) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$token_by_index(*this, &index, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$token_by_index(*this, &index,
+                                                            &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::String Erc721::token_of_owner_by_index(::rust::String owner, ::rust::String index) const {
+::rust::String Erc721::token_of_owner_by_index(::rust::String owner,
+                                               ::rust::String index) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc721$token_of_owner_by_index(*this, &owner, &index, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc721$token_of_owner_by_index(
+          *this, &owner, &index, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Construct an Erc1155 struct
-::org::defi_wallet_core::Erc1155 new_erc1155(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept {
+/// Construct an Erc1155 struct
+::org::defi_wallet_core::Erc1155
+new_erc1155(::rust::String address, ::rust::String web3api_url,
+            ::std::uint64_t chian_id) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc1155> return$;
-  org$defi_wallet_core$cxxbridge1$new_erc1155(&address, &web3api_url, chian_id, &return$.value);
+  org$defi_wallet_core$cxxbridge1$new_erc1155(&address, &web3api_url, chian_id,
+                                              &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 Erc1155::balance_of(::rust::String account_address, ::rust::String token_id) const {
+::org::defi_wallet_core::U256
+Erc1155::balance_of(::rust::String account_address,
+                    ::rust::String token_id) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$balance_of(*this, &account_address, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$balance_of(
+          *this, &account_address, &token_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String> Erc1155::balance_of_batch(::rust::Vec<::rust::String> account_addresses, ::rust::Vec<::rust::String> token_ids) const {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> account_addresses$(::std::move(account_addresses));
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> token_ids$(::std::move(token_ids));
+::rust::Vec<::rust::String>
+Erc1155::balance_of_batch(::rust::Vec<::rust::String> account_addresses,
+                          ::rust::Vec<::rust::String> token_ids) const {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> account_addresses$(
+      ::std::move(account_addresses));
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> token_ids$(
+      ::std::move(token_ids));
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$balance_of_batch(*this, &account_addresses$.value, &token_ids$.value, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$balance_of_batch(
+          *this, &account_addresses$.value, &token_ids$.value, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1494,7 +1703,8 @@ bool Erc721::is_approved_for_all(::rust::String owner, ::rust::String approved_a
 
 ::rust::String Erc1155::uri(::rust::String token_id) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$uri(*this, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$uri(
+      *this, &token_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1507,46 +1717,79 @@ bool Erc721::is_approved_for_all(::rust::String owner, ::rust::String approved_a
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Erc1155 Erc1155::interval(::std::uint64_t polling_interval_ms) noexcept {
+::org::defi_wallet_core::Erc1155
+Erc1155::interval(::std::uint64_t polling_interval_ms) noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::Erc1155> return$;
-  org$defi_wallet_core$cxxbridge1$Erc1155$interval(*this, polling_interval_ms, &return$.value);
+  org$defi_wallet_core$cxxbridge1$Erc1155$interval(*this, polling_interval_ms,
+                                                   &return$.value);
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc1155::safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::String amount, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(::std::move(additional_data));
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$safe_transfer_from(*this, &from_address, &to_address, &token_id, &amount, &additional_data$.value, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc1155::safe_transfer_from(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::String token_id, ::rust::String amount,
+    ::rust::Vec<::std::uint8_t> additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(
+      ::std::move(additional_data));
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$safe_transfer_from(
+          *this, &from_address, &to_address, &token_id, &amount,
+          &additional_data$.value, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc1155::safe_batch_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::Vec<::rust::String> token_ids, ::rust::Vec<::rust::String> amounts, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> token_ids$(::std::move(token_ids));
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> amounts$(::std::move(amounts));
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(::std::move(additional_data));
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$safe_batch_transfer_from(*this, &from_address, &to_address, &token_ids$.value, &amounts$.value, &additional_data$.value, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc1155::safe_batch_transfer_from(
+    ::rust::String from_address, ::rust::String to_address,
+    ::rust::Vec<::rust::String> token_ids, ::rust::Vec<::rust::String> amounts,
+    ::rust::Vec<::std::uint8_t> additional_data,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> token_ids$(
+      ::std::move(token_ids));
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> amounts$(
+      ::std::move(amounts));
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> additional_data$(
+      ::std::move(additional_data));
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$safe_batch_transfer_from(
+          *this, &from_address, &to_address, &token_ids$.value, &amounts$.value,
+          &additional_data$.value, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::CronosTransactionReceiptRaw Erc1155::set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const {
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$set_approval_for_all(*this, &approved_address, approved, private_key, &return$.value);
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+Erc1155::set_approval_for_all(
+    ::rust::String approved_address, bool approved,
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$set_approval_for_all(
+          *this, &approved_address, approved, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-bool Erc1155::is_approved_for_all(::rust::String owner, ::rust::String approved_address) const {
+bool Erc1155::is_approved_for_all(::rust::String owner,
+                                  ::rust::String approved_address) const {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Erc1155$is_approved_for_all(*this, &owner, &approved_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Erc1155$is_approved_for_all(
+          *this, &owner, &approved_address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/contract.rs.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/contract.rs.h
@@ -20,23 +20,19 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
 class Opaque;
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -108,11 +104,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -162,8 +156,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -199,13 +192,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -214,49 +205,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -389,8 +372,7 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
@@ -404,8 +386,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -437,8 +418,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -466,38 +446,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -505,13 +477,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -522,65 +492,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -595,18 +555,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -630,8 +585,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -655,10 +609,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -697,26 +649,20 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct Erc20;
-    struct Erc721;
-    struct Erc1155;
-  }
-}
+namespace defi_wallet_core {
+struct Erc20;
+struct Erc721;
+struct Erc1155;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -738,7 +684,8 @@ struct Erc20 final {
   /// U256 = erc20.balance_of("0xf0307093f23311FE6776a7742dB619EB3df62969");
   /// cout << balance.to_string() << endl;
   /// ```
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address) const;
+  ::org::defi_wallet_core::U256
+  balance_of(::rust::String account_address) const;
 
   /// Returns the name of the token
   /// ```
@@ -776,13 +723,15 @@ struct Erc20 final {
   /// ```
   ::org::defi_wallet_core::Erc20 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
   /// ```
   /// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
   ///    "https://cronos-testnet-3.crypto.org:8545", 383);
   /// erc20 = erc20.interval(3000);
   /// ```
-  ::org::defi_wallet_core::Erc20 interval(::std::uint64_t polling_interval_ms) noexcept;
+  ::org::defi_wallet_core::Erc20
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
   /// Moves `amount` tokens from the caller’s account to `to_address`.
   /// # Transfer 100 tokens (devnet)
@@ -808,10 +757,13 @@ struct Erc20 final {
   ///                 .legacy();
   /// erc20.transfer(signer2_address, "100", *privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer(::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer(::rust::String to_address, ::rust::String amount,
+           const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Moves `amount` tokens from `from_address` to `to_address` using the allowance mechanism.
-  /// # Transfer from signer1 to validator1 using the allowance mechanism (devnet)
+  /// Moves `amount` tokens from `from_address` to `to_address` using the
+  /// allowance mechanism. # Transfer from signer1 to validator1 using the
+  /// allowance mechanism (devnet)
   /// ```
   /// String mycronosrpc = getEnv("MYCRONOSRPC");
   /// char hdpath[100];
@@ -835,10 +787,13 @@ struct Erc20 final {
   /// erc20.transfer_from(signer1_address, validator1_address, "100",
   ///                 *signer2_privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer_from(::rust::String from_address, ::rust::String to_address,
+                ::rust::String amount,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Allows `approved_address` to withdraw from your account multiple times, up to the
-  /// `amount` amount.
+  /// Allows `approved_address` to withdraw from your account multiple times, up
+  /// to the `amount` amount.
   /// ## approves 1000 allowance (devnet)
   /// ```
   /// String mycronosrpc = getEnv("MYCRONOSRPC");
@@ -860,11 +815,15 @@ struct Erc20 final {
   /// Erc20 erc20 = new_erc20("0x5003c1fcc043D2d81fF970266bf3fa6e8C5a1F3A",
   ///                         mycronosrpc, chainid)
   ///                 .legacy();
-  /// erc20.interval(3000).approve(signer2_address, "1000", *signer1_privatekey);
+  /// erc20.interval(3000).approve(signer2_address, "1000",
+  /// *signer1_privatekey);
   /// ```
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw approve(::rust::String approved_address, ::rust::String amount, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  approve(::rust::String approved_address, ::rust::String amount,
+          const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+  /// Returns the amount which `spender` is still allowed to withdraw from
+  /// `owner`.
   /// ```
   /// Erc20 erc20 = new_erc20("0x5003c1fcc043D2d81fF970266bf3fa6e8C5a1F3A",
   ///                         mycronosrpc, chainid)
@@ -896,7 +855,8 @@ struct Erc721 final {
   ::std::uint64_t chain_id;
 
   /// Returns the number of tokens in owner's `account_address`.
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address) const;
+  ::org::defi_wallet_core::U256
+  balance_of(::rust::String account_address) const;
 
   /// Returns the owner of the `token_id` token.
   ::rust::String owner_of(::rust::String token_id) const;
@@ -913,50 +873,69 @@ struct Erc721 final {
   /// Makes a legacy transaction instead of an EIP-1559 one
   ::org::defi_wallet_core::Erc721 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
-  ::org::defi_wallet_core::Erc721 interval(::std::uint64_t polling_interval_ms) noexcept;
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
+  ::org::defi_wallet_core::Erc721
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
   /// Transfers `token_id` token from `from_address` to `to_address`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  transfer_from(::rust::String from_address, ::rust::String to_address,
+                ::rust::String token_id,
+                const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Safely transfers `token_id` token from `from_address` to `to_address`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Safely transfers `token_id` token from `from_address` to `to_address` with
   /// `additional_data`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from_with_data(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  safe_transfer_from_with_data(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id, ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Gives permission to `approved_address` to transfer `token_id` token to another account.
-  /// The approval is cleared when the token is transferred. Only a single account can be
-  /// approved at a time, so approving the zero address clears previous approvals.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw approve(::rust::String approved_address, ::rust::String token_id, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Gives permission to `approved_address` to transfer `token_id` token to
+  /// another account. The approval is cleared when the token is transferred.
+  /// Only a single account can be approved at a time, so approving the zero
+  /// address clears previous approvals.
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw
+  approve(::rust::String approved_address, ::rust::String token_id,
+          const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Enable or disable approval for a third party `approved_address` to manage all of
-  /// sender's assets
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Enable or disable approval for a third party `approved_address` to manage
+  /// all of sender's assets
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(
+      ::rust::String approved_address, bool approved,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Get the approved address for a single NFT by `token_id`
   ::rust::String get_approved(::rust::String token_id) const;
 
   /// Query if an address is an authorized `approved_address` for `owner`
-  bool is_approved_for_all(::rust::String owner, ::rust::String approved_address) const;
+  bool is_approved_for_all(::rust::String owner,
+                           ::rust::String approved_address) const;
 
   /// Returns the total amount of tokens stored by the contract.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
   ::org::defi_wallet_core::U256 total_supply() const;
 
-  /// Returns a token ID at a given index of all the tokens stored by the contract. Use along
-  /// with totalSupply to enumerate all tokens.
+  /// Returns a token ID at a given index of all the tokens stored by the
+  /// contract. Use along with totalSupply to enumerate all tokens.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
   ::rust::String token_by_index(::rust::String index) const;
 
-  /// Returns a token ID owned by owner at a given index of its token list. Use along with
-  /// balanceOf to enumerate all of owner's tokens.
+  /// Returns a token ID owned by owner at a given index of its token list. Use
+  /// along with balanceOf to enumerate all of owner's tokens.
   ///
   /// From IERC721Enumerable, an optional extension of the standard ERC721
-  ::rust::String token_of_owner_by_index(::rust::String owner, ::rust::String index) const;
+  ::rust::String token_of_owner_by_index(::rust::String owner,
+                                         ::rust::String index) const;
 
   using IsRelocatable = ::std::true_type;
 };
@@ -972,11 +951,14 @@ struct Erc1155 final {
   ::std::uint64_t chain_id;
 
   /// Returns the amount of tokens of `token_id` owned by `account_address`.
-  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address, ::rust::String token_id) const;
+  ::org::defi_wallet_core::U256 balance_of(::rust::String account_address,
+                                           ::rust::String token_id) const;
 
   /// Batched version of balance_of.
   /// Get the balance of multiple account/token pairs
-  ::rust::Vec<::rust::String> balance_of_batch(::rust::Vec<::rust::String> account_addresses, ::rust::Vec<::rust::String> token_ids) const;
+  ::rust::Vec<::rust::String>
+  balance_of_batch(::rust::Vec<::rust::String> account_addresses,
+                   ::rust::Vec<::rust::String> token_ids) const;
 
   /// Get distinct Uniform Resource Identifier (URI) for a given token
   ::rust::String uri(::rust::String token_id) const;
@@ -984,38 +966,58 @@ struct Erc1155 final {
   /// Makes a legacy transaction instead of an EIP-1559 one
   ::org::defi_wallet_core::Erc1155 legacy() noexcept;
 
-  /// Sets the default polling interval for event filters and pending transactions
-  ::org::defi_wallet_core::Erc1155 interval(::std::uint64_t polling_interval_ms) noexcept;
+  /// Sets the default polling interval for event filters and pending
+  /// transactions
+  ::org::defi_wallet_core::Erc1155
+  interval(::std::uint64_t polling_interval_ms) noexcept;
 
-  /// Transfers `amount` tokens of `token_id` from `from_address` to `to_address` with
-  /// `additional_data`.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::String token_id, ::rust::String amount, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Transfers `amount` tokens of `token_id` from `from_address` to
+  /// `to_address` with `additional_data`.
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::String token_id, ::rust::String amount,
+      ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Batched version of safeTransferFrom.
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_batch_transfer_from(::rust::String from_address, ::rust::String to_address, ::rust::Vec<::rust::String> token_ids, ::rust::Vec<::rust::String> amounts, ::rust::Vec<::std::uint8_t> additional_data, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw safe_batch_transfer_from(
+      ::rust::String from_address, ::rust::String to_address,
+      ::rust::Vec<::rust::String> token_ids,
+      ::rust::Vec<::rust::String> amounts,
+      ::rust::Vec<::std::uint8_t> additional_data,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
-  /// Enable or disable approval for a third party `approved_address` to manage all of
-  /// sender's assets
-  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(::rust::String approved_address, bool approved, const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// Enable or disable approval for a third party `approved_address` to manage
+  /// all of sender's assets
+  ::org::defi_wallet_core::CronosTransactionReceiptRaw set_approval_for_all(
+      ::rust::String approved_address, bool approved,
+      const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Query if an address is an authorized `approved_address` for `owner`
-  bool is_approved_for_all(::rust::String owner, ::rust::String approved_address) const;
+  bool is_approved_for_all(::rust::String owner,
+                           ::rust::String approved_address) const;
 
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_org$defi_wallet_core$Erc1155
 
-  /// Construct an Erc20 struct
-  /// ```
-  /// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
-  ///    "https://cronos-testnet-3.crypto.org:8545", 383);
-  /// ```
-::org::defi_wallet_core::Erc20 new_erc20(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept;
+/// Construct an Erc20 struct
+/// ```
+/// Erc20 erc20 = new_erc20("0xf0307093f23311FE6776a7742dB619EB3df62969",
+///    "https://cronos-testnet-3.crypto.org:8545", 383);
+/// ```
+::org::defi_wallet_core::Erc20 new_erc20(::rust::String address,
+                                         ::rust::String web3api_url,
+                                         ::std::uint64_t chian_id) noexcept;
 
-  /// Construct an Erc721 struct
-::org::defi_wallet_core::Erc721 new_erc721(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept;
+/// Construct an Erc721 struct
+::org::defi_wallet_core::Erc721 new_erc721(::rust::String address,
+                                           ::rust::String web3api_url,
+                                           ::std::uint64_t chian_id) noexcept;
 
-  /// Construct an Erc1155 struct
-::org::defi_wallet_core::Erc1155 new_erc1155(::rust::String address, ::rust::String web3api_url, ::std::uint64_t chian_id) noexcept;
+/// Construct an Erc1155 struct
+::org::defi_wallet_core::Erc1155 new_erc1155(::rust::String address,
+                                             ::rust::String web3api_url,
+                                             ::std::uint64_t chian_id) noexcept;
 } // namespace defi_wallet_core
 } // namespace org

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/core.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/core.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "uint.rs.h"
 #include <algorithm>
@@ -22,21 +22,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -155,11 +151,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -209,8 +203,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -246,13 +239,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -261,49 +252,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -436,16 +419,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -466,8 +447,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -488,11 +468,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -506,36 +484,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -544,25 +517,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -574,28 +539,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -607,8 +568,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -640,8 +600,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -669,38 +628,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -708,13 +659,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -725,65 +674,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -798,18 +737,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -833,8 +767,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -889,10 +822,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -931,27 +862,17 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
 namespace detail {
-template <typename... Ts>
-struct make_void {
-  using type = void;
-};
+template <typename... Ts> struct make_void { using type = void; };
 
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 template <typename Void, template <typename...> class, typename...>
 struct detect : std::false_type {};
@@ -961,8 +882,7 @@ struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
 template <template <typename...> class T, typename... A>
 using is_detected = detect<void, T, A...>;
 
-template <typename T>
-using detect_IsRelocatable = typename T::IsRelocatable;
+template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
 
 template <typename T>
 struct get_IsRelocatable
@@ -980,8 +900,7 @@ struct IsRelocatable
 #endif // CXXBRIDGE1_RELOCATABLE
 
 namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
+template <typename T, typename = void *> struct operator_new {
   void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
@@ -991,15 +910,13 @@ struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
 };
 } // namespace detail
 
-template <typename T>
-union ManuallyDrop {
+template <typename T> union ManuallyDrop {
   T value;
   ManuallyDrop(T &&value) : value(::std::move(value)) {}
   ~ManuallyDrop() {}
 };
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit {
   T value;
   void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
   MaybeUninit() {}
@@ -1014,8 +931,7 @@ struct PtrLen final {
 };
 } // namespace repr
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final {
 public:
   static Error error(repr::PtrLen repr) noexcept {
     Error error;
@@ -1029,21 +945,21 @@ public:
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    enum class CoinType : ::std::uint8_t;
-    enum class MnemonicWordCount : ::std::uint8_t;
-    enum class EthAmount : ::std::uint8_t;
-    struct EthTxInfoRaw;
-    struct CosmosSDKTxInfoRaw;
-    struct CosmosAccountInfoRaw;
-    struct CosmosTransactionReceiptRaw;
-    struct CronosTransactionReceiptRaw;
-    struct PrivateKey;
-    struct CosmosSDKMsgRaw;
-    struct Wallet;
-    struct CppLoginInfo;
-  }
-}
+namespace defi_wallet_core {
+enum class CoinType : ::std::uint8_t;
+enum class MnemonicWordCount : ::std::uint8_t;
+enum class EthAmount : ::std::uint8_t;
+struct EthTxInfoRaw;
+struct CosmosSDKTxInfoRaw;
+struct CosmosAccountInfoRaw;
+struct CosmosTransactionReceiptRaw;
+struct CronosTransactionReceiptRaw;
+struct PrivateKey;
+struct CosmosSDKMsgRaw;
+struct Wallet;
+struct CppLoginInfo;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -1208,16 +1124,19 @@ private:
 #define CXXBRIDGE1_STRUCT_org$defi_wallet_core$Wallet
 struct Wallet final : public ::rust::Opaque {
   /// returns the default address of the wallet
-  ::rust::String get_default_address(::org::defi_wallet_core::CoinType coin) const;
+  ::rust::String
+  get_default_address(::org::defi_wallet_core::CoinType coin) const;
 
   /// returns the address from index in wallet
-  ::rust::String get_address(::org::defi_wallet_core::CoinType coin, ::std::uint32_t index) const;
+  ::rust::String get_address(::org::defi_wallet_core::CoinType coin,
+                             ::std::uint32_t index) const;
 
   /// returns the ethereum address from index in wallet
   ::rust::String get_eth_address(::std::uint32_t index) const;
 
   /// return the secret key for a given derivation path
-  ::rust::Box<::org::defi_wallet_core::PrivateKey> get_key(::rust::String derivation_path) const;
+  ::rust::Box<::org::defi_wallet_core::PrivateKey>
+  get_key(::rust::String derivation_path) const;
 
   ~Wallet() = delete;
 
@@ -1235,19 +1154,23 @@ private:
 struct CppLoginInfo final : public ::rust::Opaque {
   /// Sign Login Info
   /// constructs the plaintext message and signs it according to EIP-191
-  /// (as per EIP-4361). The returned vector is a serialized recoverable signature
-  /// (as used in Ethereum).
-  ::rust::Vec<::std::uint8_t> sign_logininfo(const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// (as per EIP-4361). The returned vector is a serialized recoverable
+  /// signature (as used in Ethereum).
+  ::rust::Vec<::std::uint8_t>
+  sign_logininfo(const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Verify Login Info
-  /// It verified the signature matches + also verifies the content of the message:
+  /// It verified the signature matches + also verifies the content of the
+  /// message:
   /// - address in the message matches the address recovered from the signature
   /// - the time is valid
   /// ...
-  /// NOTE: the server may still need to do extra verifications according to its needs
-  /// (e.g. verify chain-id, nonce, uri + possibly fetch additional data associated
-  /// with the given Ethereum address, such as ERC-20/ERC-721/ERC-1155 asset ownership)
-  ::rust::Vec<::std::uint8_t> verify_logininfo(::rust::Slice<const ::std::uint8_t> signature) const;
+  /// NOTE: the server may still need to do extra verifications according to its
+  /// needs (e.g. verify chain-id, nonce, uri + possibly fetch additional data
+  /// associated with the given Ethereum address, such as
+  /// ERC-20/ERC-721/ERC-1155 asset ownership)
+  ::rust::Vec<::std::uint8_t>
+  verify_logininfo(::rust::Slice<const ::std::uint8_t> signature) const;
 
   ~CppLoginInfo() = delete;
 
@@ -1262,119 +1185,246 @@ private:
 } // namespace defi_wallet_core
 } // namespace org
 
-static_assert(
-    ::rust::IsRelocatable<::org::defi_wallet_core::U256>::value,
-    "type org::defi_wallet_core::U256 should be trivially move constructible and trivially destructible in C++ to be used as a return value of `get_eth_balance` in Rust");
+static_assert(::rust::IsRelocatable<::org::defi_wallet_core::U256>::value,
+              "type org::defi_wallet_core::U256 should be trivially move "
+              "constructible and trivially destructible in C++ to be used as a "
+              "return value of `get_eth_balance` in Rust");
 
 namespace org {
 namespace defi_wallet_core {
 extern "C" {
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_details(::rust::String *api_url, ::rust::String *address, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_details(
+    ::rust::String *api_url, ::rust::String *address,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_details_info(::rust::String *api_url, ::rust::String *address, ::org::defi_wallet_core::CosmosAccountInfoRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_details_info(
+    ::rust::String *api_url, ::rust::String *address,
+    ::org::defi_wallet_core::CosmosAccountInfoRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$broadcast_tx(::rust::String *tendermint_rpc_url, ::rust::Vec<::std::uint8_t> *raw_signed_tx, ::org::defi_wallet_core::CosmosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$broadcast_tx(
+    ::rust::String *tendermint_rpc_url,
+    ::rust::Vec<::std::uint8_t> *raw_signed_tx,
+    ::org::defi_wallet_core::CosmosTransactionReceiptRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_balance(::rust::String *api_url, ::rust::String *address, ::rust::String *denom, ::std::uint8_t api_version, ::rust::String *return$) noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$PrivateKey$operator$sizeof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$PrivateKey$operator$alignof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$CosmosSDKMsgRaw$operator$sizeof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$CosmosSDKMsgRaw$operator$alignof() noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$query_account_balance(
+    ::rust::String *api_url, ::rust::String *address, ::rust::String *denom,
+    ::std::uint8_t api_version, ::rust::String *return$) noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$PrivateKey$operator$sizeof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$PrivateKey$operator$alignof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$CosmosSDKMsgRaw$operator$sizeof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$CosmosSDKMsgRaw$operator$alignof() noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_msg_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_msg_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_single_bank_send_signdoc(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, ::rust::Vec<::std::uint8_t> *sender_pubkey, ::rust::String *recipient_address, ::std::uint64_t amount, ::rust::String *denom, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_single_bank_send_signdoc(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    ::rust::Vec<::std::uint8_t> *sender_pubkey,
+    ::rust::String *recipient_address, ::std::uint64_t amount,
+    ::rust::String *denom, ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_single_bank_send_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *recipient_address, ::std::uint64_t amount, ::rust::String *denom, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_single_bank_send_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *recipient_address, ::std::uint64_t amount,
+    ::rust::String *denom, ::rust::Vec<::std::uint8_t> *return$) noexcept;
 ::std::size_t org$defi_wallet_core$cxxbridge1$Wallet$operator$sizeof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$Wallet$operator$alignof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$Wallet$operator$alignof() noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_wallet(::rust::String *password, ::org::defi_wallet_core::MnemonicWordCount word_count, ::rust::Box<::org::defi_wallet_core::Wallet> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_wallet(
+    ::rust::String *password,
+    ::org::defi_wallet_core::MnemonicWordCount word_count,
+    ::rust::Box<::org::defi_wallet_core::Wallet> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$restore_wallet(::rust::String *mnemonic, ::rust::String *password, ::rust::Box<::org::defi_wallet_core::Wallet> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$restore_wallet(
+    ::rust::String *mnemonic, ::rust::String *password,
+    ::rust::Box<::org::defi_wallet_core::Wallet> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_default_address(const ::org::defi_wallet_core::Wallet &self, ::org::defi_wallet_core::CoinType coin, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_default_address(
+    const ::org::defi_wallet_core::Wallet &self,
+    ::org::defi_wallet_core::CoinType coin, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_address(const ::org::defi_wallet_core::Wallet &self, ::org::defi_wallet_core::CoinType coin, ::std::uint32_t index, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_address(
+    const ::org::defi_wallet_core::Wallet &self,
+    ::org::defi_wallet_core::CoinType coin, ::std::uint32_t index,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_eth_address(const ::org::defi_wallet_core::Wallet &self, ::std::uint32_t index, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_eth_address(
+    const ::org::defi_wallet_core::Wallet &self, ::std::uint32_t index,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_key(const ::org::defi_wallet_core::Wallet &self, ::rust::String *derivation_path, ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$Wallet$get_key(
+    const ::org::defi_wallet_core::Wallet &self,
+    ::rust::String *derivation_path,
+    ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
 
-::org::defi_wallet_core::PrivateKey *org$defi_wallet_core$cxxbridge1$new_privatekey() noexcept;
+::org::defi_wallet_core::PrivateKey *
+org$defi_wallet_core$cxxbridge1$new_privatekey() noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_privatekey_from_bytes(::rust::Vec<::std::uint8_t> *bytes, ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_privatekey_from_bytes(
+    ::rust::Vec<::std::uint8_t> *bytes,
+    ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_privatekey_from_hex(::rust::String *hex, ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_privatekey_from_hex(
+    ::rust::String *hex,
+    ::rust::Box<::org::defi_wallet_core::PrivateKey> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_staking_delegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *validator_address, ::std::uint64_t amount, ::rust::String *denom, bool with_reward_withdrawal, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_staking_delegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *validator_address, ::std::uint64_t amount,
+    ::rust::String *denom, bool with_reward_withdrawal,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_staking_redelegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *validator_src_address, ::rust::String *validator_dst_address, ::std::uint64_t amount, ::rust::String *denom, bool with_reward_withdrawal, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_staking_redelegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *validator_src_address,
+    ::rust::String *validator_dst_address, ::std::uint64_t amount,
+    ::rust::String *denom, bool with_reward_withdrawal,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_staking_unbond_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *validator_address, ::std::uint64_t amount, ::rust::String *denom, bool with_reward_withdrawal, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_staking_unbond_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *validator_address, ::std::uint64_t amount,
+    ::rust::String *denom, bool with_reward_withdrawal,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_distribution_set_withdraw_address_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *withdraw_address, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_distribution_set_withdraw_address_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *withdraw_address,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_distribution_withdraw_reward_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *validator_address, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_distribution_withdraw_reward_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *validator_address,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_ibc_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *receiver, ::rust::String *source_port, ::rust::String *source_channel, ::rust::String *denom, ::std::uint64_t token, ::std::uint64_t revision_height, ::std::uint64_t revision_number, ::std::uint64_t timeout_timestamp, ::rust::Vec<::std::uint8_t> *return$) noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$CppLoginInfo$operator$sizeof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$CppLoginInfo$operator$alignof() noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_ibc_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String *receiver, ::rust::String *source_port,
+    ::rust::String *source_channel, ::rust::String *denom,
+    ::std::uint64_t token, ::std::uint64_t revision_height,
+    ::std::uint64_t revision_number, ::std::uint64_t timeout_timestamp,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$CppLoginInfo$operator$sizeof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$CppLoginInfo$operator$alignof() noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_logininfo(::rust::String *msg, ::rust::Box<::org::defi_wallet_core::CppLoginInfo> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_logininfo(
+    ::rust::String *msg,
+    ::rust::Box<::org::defi_wallet_core::CppLoginInfo> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$CppLoginInfo$sign_logininfo(const ::org::defi_wallet_core::CppLoginInfo &self, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$CppLoginInfo$sign_logininfo(
+    const ::org::defi_wallet_core::CppLoginInfo &self,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$CppLoginInfo$verify_logininfo(const ::org::defi_wallet_core::CppLoginInfo &self, ::rust::Slice<const ::std::uint8_t> signature, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$CppLoginInfo$verify_logininfo(
+    const ::org::defi_wallet_core::CppLoginInfo &self,
+    ::rust::Slice<const ::std::uint8_t> signature,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::EthTxInfoRaw *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(
+    ::org::defi_wallet_core::EthTxInfoRaw *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw *tx_info, ::rust::Str network, const ::org::defi_wallet_core::PrivateKey &secret_key, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$build_eth_signed_tx(
+    ::org::defi_wallet_core::EthTxInfoRaw *tx_info, ::rust::Str network,
+    const ::org::defi_wallet_core::PrivateKey &secret_key,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$build_custom_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw *tx_info, ::std::uint64_t chain_id, bool legacy, const ::org::defi_wallet_core::PrivateKey &secret_key, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$build_custom_eth_signed_tx(
+    ::org::defi_wallet_core::EthTxInfoRaw *tx_info, ::std::uint64_t chain_id,
+    bool legacy, const ::org::defi_wallet_core::PrivateKey &secret_key,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_eth_balance(::rust::Str address, ::rust::Str api_url, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_eth_balance(
+    ::rust::Str address, ::rust::Str api_url,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_eth_nonce(::rust::Str address, ::rust::Str api_url, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_eth_nonce(
+    ::rust::Str address, ::rust::Str api_url, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$broadcast_eth_signed_raw_tx(::rust::Vec<::std::uint8_t> *raw_tx, ::rust::Str web3api_url, ::std::uint64_t polling_interval_ms, ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$broadcast_eth_signed_raw_tx(
+    ::rust::Vec<::std::uint8_t> *raw_tx, ::rust::Str web3api_url,
+    ::std::uint64_t polling_interval_ms,
+    ::org::defi_wallet_core::CronosTransactionReceiptRaw *return$) noexcept;
 } // extern "C"
 
-  /// query account details from cosmos address
-::rust::String query_account_details(::rust::String api_url, ::rust::String address) {
+/// query account details from cosmos address
+::rust::String query_account_details(::rust::String api_url,
+                                     ::rust::String address) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$query_account_details(&api_url, &address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$query_account_details(&api_url, &address,
+                                                            &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// query account details info from cosmos address
-::org::defi_wallet_core::CosmosAccountInfoRaw query_account_details_info(::rust::String api_url, ::rust::String address) {
+/// query account details info from cosmos address
+::org::defi_wallet_core::CosmosAccountInfoRaw
+query_account_details_info(::rust::String api_url, ::rust::String address) {
   ::rust::MaybeUninit<::org::defi_wallet_core::CosmosAccountInfoRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$query_account_details_info(&api_url, &address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$query_account_details_info(
+          &api_url, &address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// broadcast the cosmos transaction
-::org::defi_wallet_core::CosmosTransactionReceiptRaw broadcast_tx(::rust::String tendermint_rpc_url, ::rust::Vec<::std::uint8_t> raw_signed_tx) {
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> raw_signed_tx$(::std::move(raw_signed_tx));
-  ::rust::MaybeUninit<::org::defi_wallet_core::CosmosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$broadcast_tx(&tendermint_rpc_url, &raw_signed_tx$.value, &return$.value);
+/// broadcast the cosmos transaction
+::org::defi_wallet_core::CosmosTransactionReceiptRaw
+broadcast_tx(::rust::String tendermint_rpc_url,
+             ::rust::Vec<::std::uint8_t> raw_signed_tx) {
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> raw_signed_tx$(
+      ::std::move(raw_signed_tx));
+  ::rust::MaybeUninit<::org::defi_wallet_core::CosmosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$broadcast_tx(
+      &tendermint_rpc_url, &raw_signed_tx$.value, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// query account balance from cosmos address and denom name
-::rust::String query_account_balance(::rust::String api_url, ::rust::String address, ::rust::String denom, ::std::uint8_t api_version) {
+/// query account balance from cosmos address and denom name
+::rust::String query_account_balance(::rust::String api_url,
+                                     ::rust::String address,
+                                     ::rust::String denom,
+                                     ::std::uint8_t api_version) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$query_account_balance(&api_url, &address, &denom, api_version, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$query_account_balance(
+          &api_url, &address, &denom, api_version, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1397,36 +1447,58 @@ void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::Et
   return org$defi_wallet_core$cxxbridge1$CosmosSDKMsgRaw$operator$alignof();
 }
 
-  /// creates the signed transaction for cosmos
-::rust::Vec<::std::uint8_t> get_msg_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction for cosmos
+::rust::Vec<::std::uint8_t>
+get_msg_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                  const ::org::defi_wallet_core::PrivateKey &private_key,
+                  const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_msg_signed_tx(&tx_info$.value, private_key, msg, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_msg_signed_tx(
+          &tx_info$.value, private_key, msg, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the transaction signing payload (`SignDoc`)
-  /// for `MsgSend` from the Cosmos SDK bank module
-::rust::Vec<::std::uint8_t> get_single_bank_send_signdoc(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, ::rust::Vec<::std::uint8_t> sender_pubkey, ::rust::String recipient_address, ::std::uint64_t amount, ::rust::String denom) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> sender_pubkey$(::std::move(sender_pubkey));
+/// creates the transaction signing payload (`SignDoc`)
+/// for `MsgSend` from the Cosmos SDK bank module
+::rust::Vec<::std::uint8_t> get_single_bank_send_signdoc(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    ::rust::Vec<::std::uint8_t> sender_pubkey, ::rust::String recipient_address,
+    ::std::uint64_t amount, ::rust::String denom) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> sender_pubkey$(
+      ::std::move(sender_pubkey));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_single_bank_send_signdoc(&tx_info$.value, &sender_pubkey$.value, &recipient_address, amount, &denom, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_single_bank_send_signdoc(
+          &tx_info$.value, &sender_pubkey$.value, &recipient_address, amount,
+          &denom, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgSend` from the Cosmos SDK bank module
-::rust::Vec<::std::uint8_t> get_single_bank_send_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String recipient_address, ::std::uint64_t amount, ::rust::String denom) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgSend` from the Cosmos SDK bank module
+::rust::Vec<::std::uint8_t> get_single_bank_send_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String recipient_address, ::std::uint64_t amount,
+    ::rust::String denom) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_single_bank_send_signed_tx(&tx_info$.value, private_key, &recipient_address, amount, &denom, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_single_bank_send_signed_tx(
+          &tx_info$.value, private_key, &recipient_address, amount, &denom,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1441,38 +1513,51 @@ void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::Et
   return org$defi_wallet_core$cxxbridge1$Wallet$operator$alignof();
 }
 
-  /// generates the HD wallet with a BIP39 backup phrase (English words) and password
-::rust::Box<::org::defi_wallet_core::Wallet> new_wallet(::rust::String password, ::org::defi_wallet_core::MnemonicWordCount word_count) {
+/// generates the HD wallet with a BIP39 backup phrase (English words) and
+/// password
+::rust::Box<::org::defi_wallet_core::Wallet>
+new_wallet(::rust::String password,
+           ::org::defi_wallet_core::MnemonicWordCount word_count) {
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::Wallet>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_wallet(&password, word_count, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_wallet(
+      &password, word_count, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// recovers/imports HD wallet from a BIP39 backup phrase (English words) and password
-::rust::Box<::org::defi_wallet_core::Wallet> restore_wallet(::rust::String mnemonic, ::rust::String password) {
+/// recovers/imports HD wallet from a BIP39 backup phrase (English words) and
+/// password
+::rust::Box<::org::defi_wallet_core::Wallet>
+restore_wallet(::rust::String mnemonic, ::rust::String password) {
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::Wallet>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$restore_wallet(&mnemonic, &password, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$restore_wallet(
+      &mnemonic, &password, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::String Wallet::get_default_address(::org::defi_wallet_core::CoinType coin) const {
+::rust::String
+Wallet::get_default_address(::org::defi_wallet_core::CoinType coin) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Wallet$get_default_address(*this, coin, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Wallet$get_default_address(
+          *this, coin, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::String Wallet::get_address(::org::defi_wallet_core::CoinType coin, ::std::uint32_t index) const {
+::rust::String Wallet::get_address(::org::defi_wallet_core::CoinType coin,
+                                   ::std::uint32_t index) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Wallet$get_address(*this, coin, index, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Wallet$get_address(*this, coin, index,
+                                                         &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1481,114 +1566,173 @@ void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::Et
 
 ::rust::String Wallet::get_eth_address(::std::uint32_t index) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Wallet$get_eth_address(*this, index, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$Wallet$get_eth_address(*this, index,
+                                                             &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Box<::org::defi_wallet_core::PrivateKey> Wallet::get_key(::rust::String derivation_path) const {
+::rust::Box<::org::defi_wallet_core::PrivateKey>
+Wallet::get_key(::rust::String derivation_path) const {
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::PrivateKey>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Wallet$get_key(*this, &derivation_path, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$Wallet$get_key(
+      *this, &derivation_path, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// generates a random private key
+/// generates a random private key
 ::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey() noexcept {
-  return ::rust::Box<::org::defi_wallet_core::PrivateKey>::from_raw(org$defi_wallet_core$cxxbridge1$new_privatekey());
+  return ::rust::Box<::org::defi_wallet_core::PrivateKey>::from_raw(
+      org$defi_wallet_core$cxxbridge1$new_privatekey());
 }
 
-  /// constructs private key from bytes
-::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey_from_bytes(::rust::Vec<::std::uint8_t> bytes) {
+/// constructs private key from bytes
+::rust::Box<::org::defi_wallet_core::PrivateKey>
+new_privatekey_from_bytes(::rust::Vec<::std::uint8_t> bytes) {
   ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> bytes$(::std::move(bytes));
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::PrivateKey>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_privatekey_from_bytes(&bytes$.value, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$new_privatekey_from_bytes(&bytes$.value,
+                                                                &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// constructs private key from hex string
-::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey_from_hex(::rust::String hex) {
+/// constructs private key from hex string
+::rust::Box<::org::defi_wallet_core::PrivateKey>
+new_privatekey_from_hex(::rust::String hex) {
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::PrivateKey>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_privatekey_from_hex(&hex, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$new_privatekey_from_hex(&hex,
+                                                              &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgDelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_delegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgDelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_delegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address, ::std::uint64_t amount,
+    ::rust::String denom, bool with_reward_withdrawal) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_staking_delegate_signed_tx(&tx_info$.value, private_key, &validator_address, amount, &denom, with_reward_withdrawal, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_staking_delegate_signed_tx(
+          &tx_info$.value, private_key, &validator_address, amount, &denom,
+          with_reward_withdrawal, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgBeginRedelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_redelegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_src_address, ::rust::String validator_dst_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgBeginRedelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_redelegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_src_address, ::rust::String validator_dst_address,
+    ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_staking_redelegate_signed_tx(&tx_info$.value, private_key, &validator_src_address, &validator_dst_address, amount, &denom, with_reward_withdrawal, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_staking_redelegate_signed_tx(
+          &tx_info$.value, private_key, &validator_src_address,
+          &validator_dst_address, amount, &denom, with_reward_withdrawal,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgUndelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_unbond_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgUndelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_unbond_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address, ::std::uint64_t amount,
+    ::rust::String denom, bool with_reward_withdrawal) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_staking_unbond_signed_tx(&tx_info$.value, private_key, &validator_address, amount, &denom, with_reward_withdrawal, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_staking_unbond_signed_tx(
+          &tx_info$.value, private_key, &validator_address, amount, &denom,
+          with_reward_withdrawal, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgSetWithdrawAddress` from the Cosmos SDK distributon module
-::rust::Vec<::std::uint8_t> get_distribution_set_withdraw_address_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String withdraw_address) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgSetWithdrawAddress` from the Cosmos SDK distributon module
+::rust::Vec<::std::uint8_t> get_distribution_set_withdraw_address_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String withdraw_address) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_distribution_set_withdraw_address_signed_tx(&tx_info$.value, private_key, &withdraw_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_distribution_set_withdraw_address_signed_tx(
+          &tx_info$.value, private_key, &withdraw_address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgWithdrawDelegatorReward` from the Cosmos SDK distributon module
-::rust::Vec<::std::uint8_t> get_distribution_withdraw_reward_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgWithdrawDelegatorReward` from the Cosmos SDK distributon module
+::rust::Vec<::std::uint8_t> get_distribution_withdraw_reward_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_distribution_withdraw_reward_signed_tx(&tx_info$.value, private_key, &validator_address, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_distribution_withdraw_reward_signed_tx(
+          &tx_info$.value, private_key, &validator_address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgTransfer` from the Cosmos SDK ibc module
-::rust::Vec<::std::uint8_t> get_ibc_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String receiver, ::rust::String source_port, ::rust::String source_channel, ::rust::String denom, ::std::uint64_t token, ::std::uint64_t revision_height, ::std::uint64_t revision_number, ::std::uint64_t timeout_timestamp) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgTransfer` from the Cosmos SDK ibc module
+::rust::Vec<::std::uint8_t> get_ibc_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String receiver, ::rust::String source_port,
+    ::rust::String source_channel, ::rust::String denom, ::std::uint64_t token,
+    ::std::uint64_t revision_height, ::std::uint64_t revision_number,
+    ::std::uint64_t timeout_timestamp) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_ibc_transfer_signed_tx(&tx_info$.value, private_key, &receiver, &source_port, &source_channel, &denom, token, revision_height, revision_number, timeout_timestamp, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_ibc_transfer_signed_tx(
+          &tx_info$.value, private_key, &receiver, &source_port,
+          &source_channel, &denom, token, revision_height, revision_number,
+          timeout_timestamp, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1603,91 +1747,122 @@ void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::Et
   return org$defi_wallet_core$cxxbridge1$CppLoginInfo$operator$alignof();
 }
 
-  /// Create Login Info by `msg`
-  /// all information from the EIP-4361 plaintext message:
-  /// https://eips.ethereum.org/EIPS/eip-4361
-::rust::Box<::org::defi_wallet_core::CppLoginInfo> new_logininfo(::rust::String msg) {
-  ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::CppLoginInfo>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_logininfo(&msg, &return$.value);
+/// Create Login Info by `msg`
+/// all information from the EIP-4361 plaintext message:
+/// https://eips.ethereum.org/EIPS/eip-4361
+::rust::Box<::org::defi_wallet_core::CppLoginInfo>
+new_logininfo(::rust::String msg) {
+  ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::CppLoginInfo>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$new_logininfo(&msg, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::std::uint8_t> CppLoginInfo::sign_logininfo(const ::org::defi_wallet_core::PrivateKey &private_key) const {
+::rust::Vec<::std::uint8_t> CppLoginInfo::sign_logininfo(
+    const ::org::defi_wallet_core::PrivateKey &private_key) const {
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$CppLoginInfo$sign_logininfo(*this, private_key, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$CppLoginInfo$sign_logininfo(
+          *this, private_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::std::uint8_t> CppLoginInfo::verify_logininfo(::rust::Slice<const ::std::uint8_t> signature) const {
+::rust::Vec<::std::uint8_t> CppLoginInfo::verify_logininfo(
+    ::rust::Slice<const ::std::uint8_t> signature) const {
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$CppLoginInfo$verify_logininfo(*this, signature, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$CppLoginInfo$verify_logininfo(
+          *this, signature, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// create cronos tx info to sign
+/// create cronos tx info to sign
 ::org::defi_wallet_core::EthTxInfoRaw new_eth_tx_info() noexcept {
   ::rust::MaybeUninit<::org::defi_wallet_core::EthTxInfoRaw> return$;
   org$defi_wallet_core$cxxbridge1$new_eth_tx_info(&return$.value);
   return ::std::move(return$.value);
 }
 
-  /// sign cronos tx with private key
-::rust::Vec<::std::uint8_t> build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info, ::rust::Str network, const ::org::defi_wallet_core::PrivateKey &secret_key) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::EthTxInfoRaw> tx_info$(::std::move(tx_info));
+/// sign cronos tx with private key
+::rust::Vec<::std::uint8_t>
+build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info,
+                    ::rust::Str network,
+                    const ::org::defi_wallet_core::PrivateKey &secret_key) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::EthTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$build_eth_signed_tx(&tx_info$.value, network, secret_key, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$build_eth_signed_tx(
+          &tx_info$.value, network, secret_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// sign cronos tx with private key in custom network
-::rust::Vec<::std::uint8_t> build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info, ::std::uint64_t chain_id, bool legacy, const ::org::defi_wallet_core::PrivateKey &secret_key) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::EthTxInfoRaw> tx_info$(::std::move(tx_info));
+/// sign cronos tx with private key in custom network
+::rust::Vec<::std::uint8_t>
+build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info,
+                    ::std::uint64_t chain_id, bool legacy,
+                    const ::org::defi_wallet_core::PrivateKey &secret_key) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::EthTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$build_custom_eth_signed_tx(&tx_info$.value, chain_id, legacy, secret_key, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$build_custom_eth_signed_tx(
+          &tx_info$.value, chain_id, legacy, secret_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// given the account address, it returns the amount of native token it owns
-::org::defi_wallet_core::U256 get_eth_balance(::rust::Str address, ::rust::Str api_url) {
+/// given the account address, it returns the amount of native token it owns
+::org::defi_wallet_core::U256 get_eth_balance(::rust::Str address,
+                                              ::rust::Str api_url) {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_eth_balance(address, api_url, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_eth_balance(
+      address, api_url, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Returns the corresponding account's nonce / number of transactions
-  /// sent from it.
+/// Returns the corresponding account's nonce / number of transactions
+/// sent from it.
 ::rust::String get_eth_nonce(::rust::Str address, ::rust::Str api_url) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_eth_nonce(address, api_url, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_eth_nonce(
+      address, api_url, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// broadcast signed cronos tx
-::org::defi_wallet_core::CronosTransactionReceiptRaw broadcast_eth_signed_raw_tx(::rust::Vec<::std::uint8_t> raw_tx, ::rust::Str web3api_url, ::std::uint64_t polling_interval_ms) {
-  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> raw_tx$(::std::move(raw_tx));
-  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$broadcast_eth_signed_raw_tx(&raw_tx$.value, web3api_url, polling_interval_ms, &return$.value);
+/// broadcast signed cronos tx
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+broadcast_eth_signed_raw_tx(::rust::Vec<::std::uint8_t> raw_tx,
+                            ::rust::Str web3api_url,
+                            ::std::uint64_t polling_interval_ms) {
+  ::rust::ManuallyDrop<::rust::Vec<::std::uint8_t>> raw_tx$(
+      ::std::move(raw_tx));
+  ::rust::MaybeUninit<::org::defi_wallet_core::CronosTransactionReceiptRaw>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$broadcast_eth_signed_raw_tx(
+          &raw_tx$.value, web3api_url, polling_interval_ms, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1697,55 +1872,67 @@ void org$defi_wallet_core$cxxbridge1$new_eth_tx_info(::org::defi_wallet_core::Et
 } // namespace org
 
 extern "C" {
-::org::defi_wallet_core::Wallet *cxxbridge1$box$org$defi_wallet_core$Wallet$alloc() noexcept;
-void cxxbridge1$box$org$defi_wallet_core$Wallet$dealloc(::org::defi_wallet_core::Wallet *) noexcept;
-void cxxbridge1$box$org$defi_wallet_core$Wallet$drop(::rust::Box<::org::defi_wallet_core::Wallet> *ptr) noexcept;
+::org::defi_wallet_core::Wallet *
+cxxbridge1$box$org$defi_wallet_core$Wallet$alloc() noexcept;
+void cxxbridge1$box$org$defi_wallet_core$Wallet$dealloc(
+    ::org::defi_wallet_core::Wallet *) noexcept;
+void cxxbridge1$box$org$defi_wallet_core$Wallet$drop(
+    ::rust::Box<::org::defi_wallet_core::Wallet> *ptr) noexcept;
 
-::org::defi_wallet_core::PrivateKey *cxxbridge1$box$org$defi_wallet_core$PrivateKey$alloc() noexcept;
-void cxxbridge1$box$org$defi_wallet_core$PrivateKey$dealloc(::org::defi_wallet_core::PrivateKey *) noexcept;
-void cxxbridge1$box$org$defi_wallet_core$PrivateKey$drop(::rust::Box<::org::defi_wallet_core::PrivateKey> *ptr) noexcept;
+::org::defi_wallet_core::PrivateKey *
+cxxbridge1$box$org$defi_wallet_core$PrivateKey$alloc() noexcept;
+void cxxbridge1$box$org$defi_wallet_core$PrivateKey$dealloc(
+    ::org::defi_wallet_core::PrivateKey *) noexcept;
+void cxxbridge1$box$org$defi_wallet_core$PrivateKey$drop(
+    ::rust::Box<::org::defi_wallet_core::PrivateKey> *ptr) noexcept;
 
-::org::defi_wallet_core::CppLoginInfo *cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$alloc() noexcept;
-void cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$dealloc(::org::defi_wallet_core::CppLoginInfo *) noexcept;
-void cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$drop(::rust::Box<::org::defi_wallet_core::CppLoginInfo> *ptr) noexcept;
+::org::defi_wallet_core::CppLoginInfo *
+cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$alloc() noexcept;
+void cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$dealloc(
+    ::org::defi_wallet_core::CppLoginInfo *) noexcept;
+void cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$drop(
+    ::rust::Box<::org::defi_wallet_core::CppLoginInfo> *ptr) noexcept;
 } // extern "C"
 
 namespace rust {
 inline namespace cxxbridge1 {
 template <>
-::org::defi_wallet_core::Wallet *Box<::org::defi_wallet_core::Wallet>::allocation::alloc() noexcept {
+::org::defi_wallet_core::Wallet *
+Box<::org::defi_wallet_core::Wallet>::allocation::alloc() noexcept {
   return cxxbridge1$box$org$defi_wallet_core$Wallet$alloc();
 }
 template <>
-void Box<::org::defi_wallet_core::Wallet>::allocation::dealloc(::org::defi_wallet_core::Wallet *ptr) noexcept {
+void Box<::org::defi_wallet_core::Wallet>::allocation::dealloc(
+    ::org::defi_wallet_core::Wallet *ptr) noexcept {
   cxxbridge1$box$org$defi_wallet_core$Wallet$dealloc(ptr);
 }
-template <>
-void Box<::org::defi_wallet_core::Wallet>::drop() noexcept {
+template <> void Box<::org::defi_wallet_core::Wallet>::drop() noexcept {
   cxxbridge1$box$org$defi_wallet_core$Wallet$drop(this);
 }
 template <>
-::org::defi_wallet_core::PrivateKey *Box<::org::defi_wallet_core::PrivateKey>::allocation::alloc() noexcept {
+::org::defi_wallet_core::PrivateKey *
+Box<::org::defi_wallet_core::PrivateKey>::allocation::alloc() noexcept {
   return cxxbridge1$box$org$defi_wallet_core$PrivateKey$alloc();
 }
 template <>
-void Box<::org::defi_wallet_core::PrivateKey>::allocation::dealloc(::org::defi_wallet_core::PrivateKey *ptr) noexcept {
+void Box<::org::defi_wallet_core::PrivateKey>::allocation::dealloc(
+    ::org::defi_wallet_core::PrivateKey *ptr) noexcept {
   cxxbridge1$box$org$defi_wallet_core$PrivateKey$dealloc(ptr);
 }
-template <>
-void Box<::org::defi_wallet_core::PrivateKey>::drop() noexcept {
+template <> void Box<::org::defi_wallet_core::PrivateKey>::drop() noexcept {
   cxxbridge1$box$org$defi_wallet_core$PrivateKey$drop(this);
 }
 template <>
-::org::defi_wallet_core::CppLoginInfo *Box<::org::defi_wallet_core::CppLoginInfo>::allocation::alloc() noexcept {
+::org::defi_wallet_core::CppLoginInfo *
+Box<::org::defi_wallet_core::CppLoginInfo>::allocation::alloc() noexcept {
   return cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$alloc();
 }
 template <>
-void Box<::org::defi_wallet_core::CppLoginInfo>::allocation::dealloc(::org::defi_wallet_core::CppLoginInfo *ptr) noexcept {
+void Box<::org::defi_wallet_core::CppLoginInfo>::allocation::dealloc(
+    ::org::defi_wallet_core::CppLoginInfo *ptr) noexcept {
   cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$dealloc(ptr);
 }
-template <>
-void Box<::org::defi_wallet_core::CppLoginInfo>::drop() noexcept {
+template <> void Box<::org::defi_wallet_core::CppLoginInfo>::drop() noexcept {
   cxxbridge1$box$org$defi_wallet_core$CppLoginInfo$drop(this);
 }
 } // namespace cxxbridge1

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/lib.rs.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/lib.rs.h
@@ -19,21 +19,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -152,11 +148,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -206,8 +200,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -243,13 +236,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -258,49 +249,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -433,16 +416,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -463,8 +444,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -485,11 +465,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -503,36 +481,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -541,25 +514,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -571,28 +536,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -604,8 +565,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -637,8 +597,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -666,38 +625,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -705,13 +656,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -722,65 +671,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -795,18 +734,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -830,8 +764,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -865,10 +798,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -907,35 +838,29 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    enum class CoinType : ::std::uint8_t;
-    enum class MnemonicWordCount : ::std::uint8_t;
-    enum class EthAmount : ::std::uint8_t;
-    struct EthTxInfoRaw;
-    struct CosmosSDKTxInfoRaw;
-    struct CosmosAccountInfoRaw;
-    struct CosmosTransactionReceiptRaw;
-    struct CronosTransactionReceiptRaw;
-    struct PrivateKey;
-    struct CosmosSDKMsgRaw;
-    struct Wallet;
-    struct CppLoginInfo;
-  }
-}
+namespace defi_wallet_core {
+enum class CoinType : ::std::uint8_t;
+enum class MnemonicWordCount : ::std::uint8_t;
+enum class EthAmount : ::std::uint8_t;
+struct EthTxInfoRaw;
+struct CosmosSDKTxInfoRaw;
+struct CosmosAccountInfoRaw;
+struct CosmosTransactionReceiptRaw;
+struct CronosTransactionReceiptRaw;
+struct PrivateKey;
+struct CosmosSDKMsgRaw;
+struct Wallet;
+struct CppLoginInfo;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -1100,16 +1025,19 @@ private:
 #define CXXBRIDGE1_STRUCT_org$defi_wallet_core$Wallet
 struct Wallet final : public ::rust::Opaque {
   /// returns the default address of the wallet
-  ::rust::String get_default_address(::org::defi_wallet_core::CoinType coin) const;
+  ::rust::String
+  get_default_address(::org::defi_wallet_core::CoinType coin) const;
 
   /// returns the address from index in wallet
-  ::rust::String get_address(::org::defi_wallet_core::CoinType coin, ::std::uint32_t index) const;
+  ::rust::String get_address(::org::defi_wallet_core::CoinType coin,
+                             ::std::uint32_t index) const;
 
   /// returns the ethereum address from index in wallet
   ::rust::String get_eth_address(::std::uint32_t index) const;
 
   /// return the secret key for a given derivation path
-  ::rust::Box<::org::defi_wallet_core::PrivateKey> get_key(::rust::String derivation_path) const;
+  ::rust::Box<::org::defi_wallet_core::PrivateKey>
+  get_key(::rust::String derivation_path) const;
 
   ~Wallet() = delete;
 
@@ -1127,19 +1055,23 @@ private:
 struct CppLoginInfo final : public ::rust::Opaque {
   /// Sign Login Info
   /// constructs the plaintext message and signs it according to EIP-191
-  /// (as per EIP-4361). The returned vector is a serialized recoverable signature
-  /// (as used in Ethereum).
-  ::rust::Vec<::std::uint8_t> sign_logininfo(const ::org::defi_wallet_core::PrivateKey &private_key) const;
+  /// (as per EIP-4361). The returned vector is a serialized recoverable
+  /// signature (as used in Ethereum).
+  ::rust::Vec<::std::uint8_t>
+  sign_logininfo(const ::org::defi_wallet_core::PrivateKey &private_key) const;
 
   /// Verify Login Info
-  /// It verified the signature matches + also verifies the content of the message:
+  /// It verified the signature matches + also verifies the content of the
+  /// message:
   /// - address in the message matches the address recovered from the signature
   /// - the time is valid
   /// ...
-  /// NOTE: the server may still need to do extra verifications according to its needs
-  /// (e.g. verify chain-id, nonce, uri + possibly fetch additional data associated
-  /// with the given Ethereum address, such as ERC-20/ERC-721/ERC-1155 asset ownership)
-  ::rust::Vec<::std::uint8_t> verify_logininfo(::rust::Slice<const ::std::uint8_t> signature) const;
+  /// NOTE: the server may still need to do extra verifications according to its
+  /// needs (e.g. verify chain-id, nonce, uri + possibly fetch additional data
+  /// associated with the given Ethereum address, such as
+  /// ERC-20/ERC-721/ERC-1155 asset ownership)
+  ::rust::Vec<::std::uint8_t>
+  verify_logininfo(::rust::Slice<const ::std::uint8_t> signature) const;
 
   ~CppLoginInfo() = delete;
 
@@ -1152,90 +1084,149 @@ private:
 };
 #endif // CXXBRIDGE1_STRUCT_org$defi_wallet_core$CppLoginInfo
 
-  /// query account details from cosmos address
-::rust::String query_account_details(::rust::String api_url, ::rust::String address);
+/// query account details from cosmos address
+::rust::String query_account_details(::rust::String api_url,
+                                     ::rust::String address);
 
-  /// query account details info from cosmos address
-::org::defi_wallet_core::CosmosAccountInfoRaw query_account_details_info(::rust::String api_url, ::rust::String address);
+/// query account details info from cosmos address
+::org::defi_wallet_core::CosmosAccountInfoRaw
+query_account_details_info(::rust::String api_url, ::rust::String address);
 
-  /// broadcast the cosmos transaction
-::org::defi_wallet_core::CosmosTransactionReceiptRaw broadcast_tx(::rust::String tendermint_rpc_url, ::rust::Vec<::std::uint8_t> raw_signed_tx);
+/// broadcast the cosmos transaction
+::org::defi_wallet_core::CosmosTransactionReceiptRaw
+broadcast_tx(::rust::String tendermint_rpc_url,
+             ::rust::Vec<::std::uint8_t> raw_signed_tx);
 
-  /// query account balance from cosmos address and denom name
-::rust::String query_account_balance(::rust::String api_url, ::rust::String address, ::rust::String denom, ::std::uint8_t api_version);
+/// query account balance from cosmos address and denom name
+::rust::String query_account_balance(::rust::String api_url,
+                                     ::rust::String address,
+                                     ::rust::String denom,
+                                     ::std::uint8_t api_version);
 
-  /// creates the signed transaction for cosmos
-::rust::Vec<::std::uint8_t> get_msg_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg);
+/// creates the signed transaction for cosmos
+::rust::Vec<::std::uint8_t>
+get_msg_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                  const ::org::defi_wallet_core::PrivateKey &private_key,
+                  const ::org::defi_wallet_core::CosmosSDKMsgRaw &msg);
 
-  /// creates the transaction signing payload (`SignDoc`)
-  /// for `MsgSend` from the Cosmos SDK bank module
-::rust::Vec<::std::uint8_t> get_single_bank_send_signdoc(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, ::rust::Vec<::std::uint8_t> sender_pubkey, ::rust::String recipient_address, ::std::uint64_t amount, ::rust::String denom);
+/// creates the transaction signing payload (`SignDoc`)
+/// for `MsgSend` from the Cosmos SDK bank module
+::rust::Vec<::std::uint8_t> get_single_bank_send_signdoc(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    ::rust::Vec<::std::uint8_t> sender_pubkey, ::rust::String recipient_address,
+    ::std::uint64_t amount, ::rust::String denom);
 
-  /// creates the signed transaction
-  /// for `MsgSend` from the Cosmos SDK bank module
-::rust::Vec<::std::uint8_t> get_single_bank_send_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String recipient_address, ::std::uint64_t amount, ::rust::String denom);
+/// creates the signed transaction
+/// for `MsgSend` from the Cosmos SDK bank module
+::rust::Vec<::std::uint8_t> get_single_bank_send_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String recipient_address, ::std::uint64_t amount,
+    ::rust::String denom);
 
-  /// generates the HD wallet with a BIP39 backup phrase (English words) and password
-::rust::Box<::org::defi_wallet_core::Wallet> new_wallet(::rust::String password, ::org::defi_wallet_core::MnemonicWordCount word_count);
+/// generates the HD wallet with a BIP39 backup phrase (English words) and
+/// password
+::rust::Box<::org::defi_wallet_core::Wallet>
+new_wallet(::rust::String password,
+           ::org::defi_wallet_core::MnemonicWordCount word_count);
 
-  /// recovers/imports HD wallet from a BIP39 backup phrase (English words) and password
-::rust::Box<::org::defi_wallet_core::Wallet> restore_wallet(::rust::String mnemonic, ::rust::String password);
+/// recovers/imports HD wallet from a BIP39 backup phrase (English words) and
+/// password
+::rust::Box<::org::defi_wallet_core::Wallet>
+restore_wallet(::rust::String mnemonic, ::rust::String password);
 
-  /// generates a random private key
+/// generates a random private key
 ::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey() noexcept;
 
-  /// constructs private key from bytes
-::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey_from_bytes(::rust::Vec<::std::uint8_t> bytes);
+/// constructs private key from bytes
+::rust::Box<::org::defi_wallet_core::PrivateKey>
+new_privatekey_from_bytes(::rust::Vec<::std::uint8_t> bytes);
 
-  /// constructs private key from hex string
-::rust::Box<::org::defi_wallet_core::PrivateKey> new_privatekey_from_hex(::rust::String hex);
+/// constructs private key from hex string
+::rust::Box<::org::defi_wallet_core::PrivateKey>
+new_privatekey_from_hex(::rust::String hex);
 
-  /// creates the signed transaction
-  /// for `MsgDelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_delegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal);
+/// creates the signed transaction
+/// for `MsgDelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_delegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address, ::std::uint64_t amount,
+    ::rust::String denom, bool with_reward_withdrawal);
 
-  /// creates the signed transaction
-  /// for `MsgBeginRedelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_redelegate_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_src_address, ::rust::String validator_dst_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal);
+/// creates the signed transaction
+/// for `MsgBeginRedelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_redelegate_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_src_address, ::rust::String validator_dst_address,
+    ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal);
 
-  /// creates the signed transaction
-  /// for `MsgUndelegate` from the Cosmos SDK staking module
-::rust::Vec<::std::uint8_t> get_staking_unbond_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address, ::std::uint64_t amount, ::rust::String denom, bool with_reward_withdrawal);
+/// creates the signed transaction
+/// for `MsgUndelegate` from the Cosmos SDK staking module
+::rust::Vec<::std::uint8_t> get_staking_unbond_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address, ::std::uint64_t amount,
+    ::rust::String denom, bool with_reward_withdrawal);
 
-  /// creates the signed transaction
-  /// for `MsgSetWithdrawAddress` from the Cosmos SDK distributon module
-::rust::Vec<::std::uint8_t> get_distribution_set_withdraw_address_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String withdraw_address);
+/// creates the signed transaction
+/// for `MsgSetWithdrawAddress` from the Cosmos SDK distributon module
+::rust::Vec<::std::uint8_t> get_distribution_set_withdraw_address_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String withdraw_address);
 
-  /// creates the signed transaction
-  /// for `MsgWithdrawDelegatorReward` from the Cosmos SDK distributon module
-::rust::Vec<::std::uint8_t> get_distribution_withdraw_reward_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String validator_address);
+/// creates the signed transaction
+/// for `MsgWithdrawDelegatorReward` from the Cosmos SDK distributon module
+::rust::Vec<::std::uint8_t> get_distribution_withdraw_reward_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String validator_address);
 
-  /// creates the signed transaction
-  /// for `MsgTransfer` from the Cosmos SDK ibc module
-::rust::Vec<::std::uint8_t> get_ibc_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String receiver, ::rust::String source_port, ::rust::String source_channel, ::rust::String denom, ::std::uint64_t token, ::std::uint64_t revision_height, ::std::uint64_t revision_number, ::std::uint64_t timeout_timestamp);
+/// creates the signed transaction
+/// for `MsgTransfer` from the Cosmos SDK ibc module
+::rust::Vec<::std::uint8_t> get_ibc_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key,
+    ::rust::String receiver, ::rust::String source_port,
+    ::rust::String source_channel, ::rust::String denom, ::std::uint64_t token,
+    ::std::uint64_t revision_height, ::std::uint64_t revision_number,
+    ::std::uint64_t timeout_timestamp);
 
-  /// Create Login Info by `msg`
-  /// all information from the EIP-4361 plaintext message:
-  /// https://eips.ethereum.org/EIPS/eip-4361
-::rust::Box<::org::defi_wallet_core::CppLoginInfo> new_logininfo(::rust::String msg);
+/// Create Login Info by `msg`
+/// all information from the EIP-4361 plaintext message:
+/// https://eips.ethereum.org/EIPS/eip-4361
+::rust::Box<::org::defi_wallet_core::CppLoginInfo>
+new_logininfo(::rust::String msg);
 
-  /// create cronos tx info to sign
+/// create cronos tx info to sign
 ::org::defi_wallet_core::EthTxInfoRaw new_eth_tx_info() noexcept;
 
-  /// sign cronos tx with private key
-::rust::Vec<::std::uint8_t> build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info, ::rust::Str network, const ::org::defi_wallet_core::PrivateKey &secret_key);
+/// sign cronos tx with private key
+::rust::Vec<::std::uint8_t>
+build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info,
+                    ::rust::Str network,
+                    const ::org::defi_wallet_core::PrivateKey &secret_key);
 
-  /// sign cronos tx with private key in custom network
-::rust::Vec<::std::uint8_t> build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info, ::std::uint64_t chain_id, bool legacy, const ::org::defi_wallet_core::PrivateKey &secret_key);
+/// sign cronos tx with private key in custom network
+::rust::Vec<::std::uint8_t>
+build_eth_signed_tx(::org::defi_wallet_core::EthTxInfoRaw tx_info,
+                    ::std::uint64_t chain_id, bool legacy,
+                    const ::org::defi_wallet_core::PrivateKey &secret_key);
 
-  /// given the account address, it returns the amount of native token it owns
-::org::defi_wallet_core::U256 get_eth_balance(::rust::Str address, ::rust::Str api_url);
+/// given the account address, it returns the amount of native token it owns
+::org::defi_wallet_core::U256 get_eth_balance(::rust::Str address,
+                                              ::rust::Str api_url);
 
-  /// Returns the corresponding account's nonce / number of transactions
-  /// sent from it.
+/// Returns the corresponding account's nonce / number of transactions
+/// sent from it.
 ::rust::String get_eth_nonce(::rust::Str address, ::rust::Str api_url);
 
-  /// broadcast signed cronos tx
-::org::defi_wallet_core::CronosTransactionReceiptRaw broadcast_eth_signed_raw_tx(::rust::Vec<::std::uint8_t> raw_tx, ::rust::Str web3api_url, ::std::uint64_t polling_interval_ms);
+/// broadcast signed cronos tx
+::org::defi_wallet_core::CronosTransactionReceiptRaw
+broadcast_eth_signed_raw_tx(::rust::Vec<::std::uint8_t> raw_tx,
+                            ::rust::Str web3api_url,
+                            ::std::uint64_t polling_interval_ms);
 } // namespace defi_wallet_core
 } // namespace org

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/nft.rs.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/nft.rs.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "lib.rs.h"
 #include "../../nft.h"
@@ -23,21 +23,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -109,11 +105,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -163,8 +157,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -200,13 +193,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -215,49 +206,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -390,16 +373,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -420,8 +401,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -442,11 +422,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -460,36 +438,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -498,25 +471,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -528,28 +493,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -561,8 +522,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -594,8 +554,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -623,38 +582,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -662,13 +613,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -679,65 +628,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -752,18 +691,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -787,8 +721,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -843,10 +776,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -885,27 +816,17 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
 namespace detail {
-template <typename... Ts>
-struct make_void {
-  using type = void;
-};
+template <typename... Ts> struct make_void { using type = void; };
 
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 template <typename Void, template <typename...> class, typename...>
 struct detect : std::false_type {};
@@ -915,8 +836,7 @@ struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
 template <template <typename...> class T, typename... A>
 using is_detected = detect<void, T, A...>;
 
-template <typename T>
-using detect_IsRelocatable = typename T::IsRelocatable;
+template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
 
 template <typename T>
 struct get_IsRelocatable
@@ -934,8 +854,7 @@ struct IsRelocatable
 #endif // CXXBRIDGE1_RELOCATABLE
 
 namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
+template <typename T, typename = void *> struct operator_new {
   void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
@@ -945,15 +864,13 @@ struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
 };
 } // namespace detail
 
-template <typename T>
-union ManuallyDrop {
+template <typename T> union ManuallyDrop {
   T value;
   ManuallyDrop(T &&value) : value(::std::move(value)) {}
   ~ManuallyDrop() {}
 };
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit {
   T value;
   void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
   MaybeUninit() {}
@@ -968,8 +885,7 @@ struct PtrLen final {
 };
 } // namespace repr
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final {
 public:
   static Error error(repr::PtrLen repr) noexcept {
     Error error;
@@ -983,16 +899,16 @@ public:
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct Denom;
-    struct BaseNft;
-    struct IdCollection;
-    struct Owner;
-    struct Collection;
-    using Pagination = ::org::defi_wallet_core::Pagination;
-    struct GrpcClient;
-  }
-}
+namespace defi_wallet_core {
+struct Denom;
+struct BaseNft;
+struct IdCollection;
+struct Owner;
+struct Collection;
+using Pagination = ::org::defi_wallet_core::Pagination;
+struct GrpcClient;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -1063,10 +979,14 @@ struct GrpcClient final : public ::rust::Opaque {
   ::std::uint64_t supply(::rust::String denom_id, ::rust::String owner) const;
 
   /// Owner queries the NFTs of the specified owner
-  ::org::defi_wallet_core::Owner owner(::rust::String denom_id, ::rust::String owner, const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::org::defi_wallet_core::Owner
+  owner(::rust::String denom_id, ::rust::String owner,
+        const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// Collection queries the NFTs of the specified denom
-  ::org::defi_wallet_core::Collection collection(::rust::String denom_id, const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::org::defi_wallet_core::Collection
+  collection(::rust::String denom_id,
+             const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// Denom queries the definition of a given denom
   ::org::defi_wallet_core::Denom denom(::rust::String denom_id) const;
@@ -1075,10 +995,12 @@ struct GrpcClient final : public ::rust::Opaque {
   ::org::defi_wallet_core::Denom denom_by_name(::rust::String denom_name) const;
 
   /// Denoms queries all the denoms
-  ::rust::Vec<::org::defi_wallet_core::Denom> denoms(const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::rust::Vec<::org::defi_wallet_core::Denom>
+  denoms(const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// NFT queries the NFT for the given denom and token ID
-  ::org::defi_wallet_core::BaseNft nft(::rust::String denom_id, ::rust::String token_id) const;
+  ::org::defi_wallet_core::BaseNft nft(::rust::String denom_id,
+                                       ::rust::String token_id) const;
 
   ~GrpcClient() = delete;
 
@@ -1095,132 +1017,237 @@ private:
 
 static_assert(
     ::rust::IsRelocatable<::org::defi_wallet_core::CosmosSDKTxInfoRaw>::value,
-    "type org::defi_wallet_core::CosmosSDKTxInfoRaw should be trivially move constructible and trivially destructible in C++ to be used as an argument of `get_nft_issue_denom_signed_tx`, `get_nft_mint_signed_tx`, `get_nft_edit_signed_tx` in Rust");
+    "type org::defi_wallet_core::CosmosSDKTxInfoRaw should be trivially move "
+    "constructible and trivially destructible in C++ to be used as an argument "
+    "of `get_nft_issue_denom_signed_tx`, `get_nft_mint_signed_tx`, "
+    "`get_nft_edit_signed_tx` in Rust");
 
 namespace org {
 namespace defi_wallet_core {
 extern "C" {
-bool org$defi_wallet_core$cxxbridge1$Pagination$get_enable(const ::org::defi_wallet_core::Pagination &self) noexcept {
-  bool (::org::defi_wallet_core::Pagination::*get_enable$)() const = &::org::defi_wallet_core::Pagination::get_enable;
+bool org$defi_wallet_core$cxxbridge1$Pagination$get_enable(
+    const ::org::defi_wallet_core::Pagination &self) noexcept {
+  bool (::org::defi_wallet_core::Pagination::*get_enable$)() const =
+      &::org::defi_wallet_core::Pagination::get_enable;
   return (self.*get_enable$)();
 }
 
-void org$defi_wallet_core$cxxbridge1$Pagination$get_key(const ::org::defi_wallet_core::Pagination &self, ::rust::Vec<::std::uint8_t> *return$) noexcept {
-  ::rust::Vec<::std::uint8_t> (::org::defi_wallet_core::Pagination::*get_key$)() const = &::org::defi_wallet_core::Pagination::get_key;
-  new (return$) ::rust::Vec<::std::uint8_t>((self.*get_key$)());
+void org$defi_wallet_core$cxxbridge1$Pagination$get_key(
+    const ::org::defi_wallet_core::Pagination &self,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept {
+  ::rust::Vec<::std::uint8_t> (::org::defi_wallet_core::Pagination::*get_key$)()
+      const = &::org::defi_wallet_core::Pagination::get_key;
+  new (return$)::rust::Vec<::std::uint8_t>((self.*get_key$)());
 }
 
-::std::uint64_t org$defi_wallet_core$cxxbridge1$Pagination$get_offset(const ::org::defi_wallet_core::Pagination &self) noexcept {
-  ::std::uint64_t (::org::defi_wallet_core::Pagination::*get_offset$)() const = &::org::defi_wallet_core::Pagination::get_offset;
+::std::uint64_t org$defi_wallet_core$cxxbridge1$Pagination$get_offset(
+    const ::org::defi_wallet_core::Pagination &self) noexcept {
+  ::std::uint64_t (::org::defi_wallet_core::Pagination::*get_offset$)() const =
+      &::org::defi_wallet_core::Pagination::get_offset;
   return (self.*get_offset$)();
 }
 
-::std::uint64_t org$defi_wallet_core$cxxbridge1$Pagination$get_limit(const ::org::defi_wallet_core::Pagination &self) noexcept {
-  ::std::uint64_t (::org::defi_wallet_core::Pagination::*get_limit$)() const = &::org::defi_wallet_core::Pagination::get_limit;
+::std::uint64_t org$defi_wallet_core$cxxbridge1$Pagination$get_limit(
+    const ::org::defi_wallet_core::Pagination &self) noexcept {
+  ::std::uint64_t (::org::defi_wallet_core::Pagination::*get_limit$)() const =
+      &::org::defi_wallet_core::Pagination::get_limit;
   return (self.*get_limit$)();
 }
 
-bool org$defi_wallet_core$cxxbridge1$Pagination$get_count_total(const ::org::defi_wallet_core::Pagination &self) noexcept {
-  bool (::org::defi_wallet_core::Pagination::*get_count_total$)() const = &::org::defi_wallet_core::Pagination::get_count_total;
+bool org$defi_wallet_core$cxxbridge1$Pagination$get_count_total(
+    const ::org::defi_wallet_core::Pagination &self) noexcept {
+  bool (::org::defi_wallet_core::Pagination::*get_count_total$)() const =
+      &::org::defi_wallet_core::Pagination::get_count_total;
   return (self.*get_count_total$)();
 }
 
-bool org$defi_wallet_core$cxxbridge1$Pagination$get_reverse(const ::org::defi_wallet_core::Pagination &self) noexcept {
-  bool (::org::defi_wallet_core::Pagination::*get_reverse$)() const = &::org::defi_wallet_core::Pagination::get_reverse;
+bool org$defi_wallet_core$cxxbridge1$Pagination$get_reverse(
+    const ::org::defi_wallet_core::Pagination &self) noexcept {
+  bool (::org::defi_wallet_core::Pagination::*get_reverse$)() const =
+      &::org::defi_wallet_core::Pagination::get_reverse;
   return (self.*get_reverse$)();
 }
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_issue_denom_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id, ::rust::String *name, ::rust::String *schema, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+org$defi_wallet_core$cxxbridge1$get_nft_issue_denom_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id,
+    ::rust::String *name, ::rust::String *schema,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_mint_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id, ::rust::String *denom_id, ::rust::String *name, ::rust::String *uri, ::rust::String *data, ::rust::String *recipient, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_mint_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id,
+    ::rust::String *denom_id, ::rust::String *name, ::rust::String *uri,
+    ::rust::String *data, ::rust::String *recipient,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_edit_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id, ::rust::String *denom_id, ::rust::String *name, ::rust::String *uri, ::rust::String *data, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_edit_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id,
+    ::rust::String *denom_id, ::rust::String *name, ::rust::String *uri,
+    ::rust::String *data, ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id, ::rust::String *denom_id, ::rust::String *recipient, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id,
+    ::rust::String *denom_id, ::rust::String *recipient,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_burn_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id, ::rust::String *denom_id, ::rust::Vec<::std::uint8_t> *return$) noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$GrpcClient$operator$sizeof() noexcept;
-::std::size_t org$defi_wallet_core$cxxbridge1$GrpcClient$operator$alignof() noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$get_nft_burn_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw *tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String *id,
+    ::rust::String *denom_id, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$GrpcClient$operator$sizeof() noexcept;
+::std::size_t
+org$defi_wallet_core$cxxbridge1$GrpcClient$operator$alignof() noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_grpc_client(::rust::String *grpc_url, ::rust::Box<::org::defi_wallet_core::GrpcClient> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$new_grpc_client(
+    ::rust::String *grpc_url,
+    ::rust::Box<::org::defi_wallet_core::GrpcClient> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$supply(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id, ::rust::String *owner, ::std::uint64_t *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$supply(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id,
+    ::rust::String *owner, ::std::uint64_t *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$owner(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id, ::rust::String *owner, const ::org::defi_wallet_core::Pagination &pagination, ::org::defi_wallet_core::Owner *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$owner(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id,
+    ::rust::String *owner,
+    const ::org::defi_wallet_core::Pagination &pagination,
+    ::org::defi_wallet_core::Owner *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$collection(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id, const ::org::defi_wallet_core::Pagination &pagination, ::org::defi_wallet_core::Collection *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$collection(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id,
+    const ::org::defi_wallet_core::Pagination &pagination,
+    ::org::defi_wallet_core::Collection *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denom(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id, ::org::defi_wallet_core::Denom *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denom(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id,
+    ::org::defi_wallet_core::Denom *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denom_by_name(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_name, ::org::defi_wallet_core::Denom *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denom_by_name(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_name,
+    ::org::defi_wallet_core::Denom *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denoms(const ::org::defi_wallet_core::GrpcClient &self, const ::org::defi_wallet_core::Pagination &pagination, ::rust::Vec<::org::defi_wallet_core::Denom> *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$denoms(
+    const ::org::defi_wallet_core::GrpcClient &self,
+    const ::org::defi_wallet_core::Pagination &pagination,
+    ::rust::Vec<::org::defi_wallet_core::Denom> *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$nft(const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id, ::rust::String *token_id, ::org::defi_wallet_core::BaseNft *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$GrpcClient$nft(
+    const ::org::defi_wallet_core::GrpcClient &self, ::rust::String *denom_id,
+    ::rust::String *token_id,
+    ::org::defi_wallet_core::BaseNft *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Owner$to_string(const ::org::defi_wallet_core::Owner &self, ::rust::String *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Owner$to_string(
+    const ::org::defi_wallet_core::Owner &self,
+    ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Collection$to_string(const ::org::defi_wallet_core::Collection &self, ::rust::String *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Collection$to_string(
+    const ::org::defi_wallet_core::Collection &self,
+    ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$Denom$to_string(const ::org::defi_wallet_core::Denom &self, ::rust::String *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$Denom$to_string(
+    const ::org::defi_wallet_core::Denom &self,
+    ::rust::String *return$) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$BaseNft$to_string(const ::org::defi_wallet_core::BaseNft &self, ::rust::String *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$BaseNft$to_string(
+    const ::org::defi_wallet_core::BaseNft &self,
+    ::rust::String *return$) noexcept;
 } // extern "C"
 
-  /// creates the signed transaction
-  /// for `MsgIssueDenom` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_issue_denom_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String name, ::rust::String schema) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgIssueDenom` from the Chainmain nft module
+::rust::Vec<::std::uint8_t> get_nft_issue_denom_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id,
+    ::rust::String name, ::rust::String schema) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_nft_issue_denom_signed_tx(&tx_info$.value, private_key, &id, &name, &schema, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_nft_issue_denom_signed_tx(
+          &tx_info$.value, private_key, &id, &name, &schema, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgMintNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_mint_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String name, ::rust::String uri, ::rust::String data, ::rust::String recipient) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgMintNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_mint_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id,
+                       ::rust::String name, ::rust::String uri,
+                       ::rust::String data, ::rust::String recipient) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_nft_mint_signed_tx(&tx_info$.value, private_key, &id, &denom_id, &name, &uri, &data, &recipient, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_nft_mint_signed_tx(
+          &tx_info$.value, private_key, &id, &denom_id, &name, &uri, &data,
+          &recipient, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgEditNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_edit_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String name, ::rust::String uri, ::rust::String data) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgEditNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_edit_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id,
+                       ::rust::String name, ::rust::String uri,
+                       ::rust::String data) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_nft_edit_signed_tx(&tx_info$.value, private_key, &id, &denom_id, &name, &uri, &data, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_nft_edit_signed_tx(
+          &tx_info$.value, private_key, &id, &denom_id, &name, &uri, &data,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgTransferNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String recipient) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgTransferNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t> get_nft_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id,
+    ::rust::String denom_id, ::rust::String recipient) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_nft_transfer_signed_tx(&tx_info$.value, private_key, &id, &denom_id, &recipient, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_nft_transfer_signed_tx(
+          &tx_info$.value, private_key, &id, &denom_id, &recipient,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// creates the signed transaction
-  /// for `MsgBurnNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_burn_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id) {
-  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(::std::move(tx_info));
+/// creates the signed transaction
+/// for `MsgBurnNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_burn_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id) {
+  ::rust::ManuallyDrop<::org::defi_wallet_core::CosmosSDKTxInfoRaw> tx_info$(
+      ::std::move(tx_info));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$get_nft_burn_signed_tx(&tx_info$.value, private_key, &id, &denom_id, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$get_nft_burn_signed_tx(
+          &tx_info$.value, private_key, &id, &denom_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1235,73 +1262,97 @@ void org$defi_wallet_core$cxxbridge1$BaseNft$to_string(const ::org::defi_wallet_
   return org$defi_wallet_core$cxxbridge1$GrpcClient$operator$alignof();
 }
 
-  /// Create a new grpc client
-::rust::Box<::org::defi_wallet_core::GrpcClient> new_grpc_client(::rust::String grpc_url) {
+/// Create a new grpc client
+::rust::Box<::org::defi_wallet_core::GrpcClient>
+new_grpc_client(::rust::String grpc_url) {
   ::rust::MaybeUninit<::rust::Box<::org::defi_wallet_core::GrpcClient>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_grpc_client(&grpc_url, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$new_grpc_client(
+      &grpc_url, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::std::uint64_t GrpcClient::supply(::rust::String denom_id, ::rust::String owner) const {
+::std::uint64_t GrpcClient::supply(::rust::String denom_id,
+                                   ::rust::String owner) const {
   ::rust::MaybeUninit<::std::uint64_t> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$supply(*this, &denom_id, &owner, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$supply(*this, &denom_id,
+                                                        &owner, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Owner GrpcClient::owner(::rust::String denom_id, ::rust::String owner, const ::org::defi_wallet_core::Pagination &pagination) const {
+::org::defi_wallet_core::Owner
+GrpcClient::owner(::rust::String denom_id, ::rust::String owner,
+                  const ::org::defi_wallet_core::Pagination &pagination) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::Owner> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$owner(*this, &denom_id, &owner, pagination, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$owner(
+          *this, &denom_id, &owner, pagination, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Collection GrpcClient::collection(::rust::String denom_id, const ::org::defi_wallet_core::Pagination &pagination) const {
+::org::defi_wallet_core::Collection GrpcClient::collection(
+    ::rust::String denom_id,
+    const ::org::defi_wallet_core::Pagination &pagination) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::Collection> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$collection(*this, &denom_id, pagination, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$collection(
+          *this, &denom_id, pagination, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Denom GrpcClient::denom(::rust::String denom_id) const {
+::org::defi_wallet_core::Denom
+GrpcClient::denom(::rust::String denom_id) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::Denom> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$denom(*this, &denom_id, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$denom(*this, &denom_id,
+                                                       &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::Denom GrpcClient::denom_by_name(::rust::String denom_name) const {
+::org::defi_wallet_core::Denom
+GrpcClient::denom_by_name(::rust::String denom_name) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::Denom> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$denom_by_name(*this, &denom_name, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$denom_by_name(
+          *this, &denom_name, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::org::defi_wallet_core::Denom> GrpcClient::denoms(const ::org::defi_wallet_core::Pagination &pagination) const {
+::rust::Vec<::org::defi_wallet_core::Denom> GrpcClient::denoms(
+    const ::org::defi_wallet_core::Pagination &pagination) const {
   ::rust::MaybeUninit<::rust::Vec<::org::defi_wallet_core::Denom>> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$denoms(*this, pagination, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$GrpcClient$denoms(*this, pagination,
+                                                        &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::BaseNft GrpcClient::nft(::rust::String denom_id, ::rust::String token_id) const {
+::org::defi_wallet_core::BaseNft
+GrpcClient::nft(::rust::String denom_id, ::rust::String token_id) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::BaseNft> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$nft(*this, &denom_id, &token_id, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$GrpcClient$nft(
+      *this, &denom_id, &token_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1335,78 +1386,121 @@ void org$defi_wallet_core$cxxbridge1$BaseNft$to_string(const ::org::defi_wallet_
 } // namespace org
 
 extern "C" {
-void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$new(const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$drop(::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$len(const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$capacity(const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
-const ::org::defi_wallet_core::IdCollection *cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$data(const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$reserve_total(::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$set_len(::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$truncate(::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$new(
+    const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$drop(
+    ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$len(
+    const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$capacity(
+    const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
+const ::org::defi_wallet_core::IdCollection *
+cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$data(
+    const ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$reserve_total(
+    ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$set_len(
+    ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$truncate(
+    ::rust::Vec<::org::defi_wallet_core::IdCollection> *ptr,
+    ::std::size_t len) noexcept;
 
-void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$new(const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$drop(::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$len(const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$capacity(const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
-const ::org::defi_wallet_core::BaseNft *cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$data(const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$reserve_total(::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$set_len(::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$truncate(::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$new(
+    const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$drop(
+    ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$len(
+    const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$capacity(
+    const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
+const ::org::defi_wallet_core::BaseNft *
+cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$data(
+    const ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$reserve_total(
+    ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$set_len(
+    ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$truncate(
+    ::rust::Vec<::org::defi_wallet_core::BaseNft> *ptr,
+    ::std::size_t len) noexcept;
 
-::org::defi_wallet_core::GrpcClient *cxxbridge1$box$org$defi_wallet_core$GrpcClient$alloc() noexcept;
-void cxxbridge1$box$org$defi_wallet_core$GrpcClient$dealloc(::org::defi_wallet_core::GrpcClient *) noexcept;
-void cxxbridge1$box$org$defi_wallet_core$GrpcClient$drop(::rust::Box<::org::defi_wallet_core::GrpcClient> *ptr) noexcept;
+::org::defi_wallet_core::GrpcClient *
+cxxbridge1$box$org$defi_wallet_core$GrpcClient$alloc() noexcept;
+void cxxbridge1$box$org$defi_wallet_core$GrpcClient$dealloc(
+    ::org::defi_wallet_core::GrpcClient *) noexcept;
+void cxxbridge1$box$org$defi_wallet_core$GrpcClient$drop(
+    ::rust::Box<::org::defi_wallet_core::GrpcClient> *ptr) noexcept;
 
-void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$new(const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$drop(::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$Denom$len(const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$Denom$capacity(const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
-const ::org::defi_wallet_core::Denom *cxxbridge1$rust_vec$org$defi_wallet_core$Denom$data(const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$reserve_total(::rust::Vec<::org::defi_wallet_core::Denom> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$set_len(::rust::Vec<::org::defi_wallet_core::Denom> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$truncate(::rust::Vec<::org::defi_wallet_core::Denom> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$new(
+    const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$drop(
+    ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$Denom$len(
+    const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$org$defi_wallet_core$Denom$capacity(
+    const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
+const ::org::defi_wallet_core::Denom *
+cxxbridge1$rust_vec$org$defi_wallet_core$Denom$data(
+    const ::rust::Vec<::org::defi_wallet_core::Denom> *ptr) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$reserve_total(
+    ::rust::Vec<::org::defi_wallet_core::Denom> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$set_len(
+    ::rust::Vec<::org::defi_wallet_core::Denom> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$org$defi_wallet_core$Denom$truncate(
+    ::rust::Vec<::org::defi_wallet_core::Denom> *ptr,
+    ::std::size_t len) noexcept;
 } // extern "C"
 
 namespace rust {
 inline namespace cxxbridge1 {
-template <>
-Vec<::org::defi_wallet_core::IdCollection>::Vec() noexcept {
+template <> Vec<::org::defi_wallet_core::IdCollection>::Vec() noexcept {
   cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$new(this);
 }
-template <>
-void Vec<::org::defi_wallet_core::IdCollection>::drop() noexcept {
+template <> void Vec<::org::defi_wallet_core::IdCollection>::drop() noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$drop(this);
 }
 template <>
-::std::size_t Vec<::org::defi_wallet_core::IdCollection>::size() const noexcept {
+::std::size_t
+Vec<::org::defi_wallet_core::IdCollection>::size() const noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$len(this);
 }
 template <>
-::std::size_t Vec<::org::defi_wallet_core::IdCollection>::capacity() const noexcept {
+::std::size_t
+Vec<::org::defi_wallet_core::IdCollection>::capacity() const noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$capacity(this);
 }
 template <>
-const ::org::defi_wallet_core::IdCollection *Vec<::org::defi_wallet_core::IdCollection>::data() const noexcept {
+const ::org::defi_wallet_core::IdCollection *
+Vec<::org::defi_wallet_core::IdCollection>::data() const noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$data(this);
 }
 template <>
-void Vec<::org::defi_wallet_core::IdCollection>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$reserve_total(this, new_cap);
+void Vec<::org::defi_wallet_core::IdCollection>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$reserve_total(
+      this, new_cap);
 }
 template <>
-void Vec<::org::defi_wallet_core::IdCollection>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$set_len(this, len);
+void Vec<::org::defi_wallet_core::IdCollection>::set_len(
+    ::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$set_len(this,
+                                                                       len);
 }
 template <>
 void Vec<::org::defi_wallet_core::IdCollection>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$truncate(this, len);
+  return cxxbridge1$rust_vec$org$defi_wallet_core$IdCollection$truncate(this,
+                                                                        len);
 }
-template <>
-Vec<::org::defi_wallet_core::BaseNft>::Vec() noexcept {
+template <> Vec<::org::defi_wallet_core::BaseNft>::Vec() noexcept {
   cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$new(this);
 }
-template <>
-void Vec<::org::defi_wallet_core::BaseNft>::drop() noexcept {
+template <> void Vec<::org::defi_wallet_core::BaseNft>::drop() noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$drop(this);
 }
 template <>
@@ -1418,15 +1512,19 @@ template <>
   return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$capacity(this);
 }
 template <>
-const ::org::defi_wallet_core::BaseNft *Vec<::org::defi_wallet_core::BaseNft>::data() const noexcept {
+const ::org::defi_wallet_core::BaseNft *
+Vec<::org::defi_wallet_core::BaseNft>::data() const noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$data(this);
 }
 template <>
-void Vec<::org::defi_wallet_core::BaseNft>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$reserve_total(this, new_cap);
+void Vec<::org::defi_wallet_core::BaseNft>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$reserve_total(
+      this, new_cap);
 }
 template <>
-void Vec<::org::defi_wallet_core::BaseNft>::set_len(::std::size_t len) noexcept {
+void Vec<::org::defi_wallet_core::BaseNft>::set_len(
+    ::std::size_t len) noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$set_len(this, len);
 }
 template <>
@@ -1434,23 +1532,22 @@ void Vec<::org::defi_wallet_core::BaseNft>::truncate(::std::size_t len) {
   return cxxbridge1$rust_vec$org$defi_wallet_core$BaseNft$truncate(this, len);
 }
 template <>
-::org::defi_wallet_core::GrpcClient *Box<::org::defi_wallet_core::GrpcClient>::allocation::alloc() noexcept {
+::org::defi_wallet_core::GrpcClient *
+Box<::org::defi_wallet_core::GrpcClient>::allocation::alloc() noexcept {
   return cxxbridge1$box$org$defi_wallet_core$GrpcClient$alloc();
 }
 template <>
-void Box<::org::defi_wallet_core::GrpcClient>::allocation::dealloc(::org::defi_wallet_core::GrpcClient *ptr) noexcept {
+void Box<::org::defi_wallet_core::GrpcClient>::allocation::dealloc(
+    ::org::defi_wallet_core::GrpcClient *ptr) noexcept {
   cxxbridge1$box$org$defi_wallet_core$GrpcClient$dealloc(ptr);
 }
-template <>
-void Box<::org::defi_wallet_core::GrpcClient>::drop() noexcept {
+template <> void Box<::org::defi_wallet_core::GrpcClient>::drop() noexcept {
   cxxbridge1$box$org$defi_wallet_core$GrpcClient$drop(this);
 }
-template <>
-Vec<::org::defi_wallet_core::Denom>::Vec() noexcept {
+template <> Vec<::org::defi_wallet_core::Denom>::Vec() noexcept {
   cxxbridge1$rust_vec$org$defi_wallet_core$Denom$new(this);
 }
-template <>
-void Vec<::org::defi_wallet_core::Denom>::drop() noexcept {
+template <> void Vec<::org::defi_wallet_core::Denom>::drop() noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$Denom$drop(this);
 }
 template <>
@@ -1462,12 +1559,15 @@ template <>
   return cxxbridge1$rust_vec$org$defi_wallet_core$Denom$capacity(this);
 }
 template <>
-const ::org::defi_wallet_core::Denom *Vec<::org::defi_wallet_core::Denom>::data() const noexcept {
+const ::org::defi_wallet_core::Denom *
+Vec<::org::defi_wallet_core::Denom>::data() const noexcept {
   return cxxbridge1$rust_vec$org$defi_wallet_core$Denom$data(this);
 }
 template <>
-void Vec<::org::defi_wallet_core::Denom>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$org$defi_wallet_core$Denom$reserve_total(this, new_cap);
+void Vec<::org::defi_wallet_core::Denom>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$org$defi_wallet_core$Denom$reserve_total(this,
+                                                                      new_cap);
 }
 template <>
 void Vec<::org::defi_wallet_core::Denom>::set_len(::std::size_t len) noexcept {

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/nft.rs.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/nft.rs.h
@@ -20,21 +20,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -106,11 +102,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -160,8 +154,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -197,13 +190,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -212,49 +203,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -387,16 +370,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -417,8 +398,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -439,11 +419,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -457,36 +435,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -495,25 +468,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -525,28 +490,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -558,8 +519,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -591,8 +551,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -620,38 +579,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -659,13 +610,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -676,65 +625,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -749,18 +688,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -784,8 +718,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -819,10 +752,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -861,30 +792,24 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct Denom;
-    struct BaseNft;
-    struct IdCollection;
-    struct Owner;
-    struct Collection;
-    using Pagination = ::org::defi_wallet_core::Pagination;
-    struct GrpcClient;
-  }
-}
+namespace defi_wallet_core {
+struct Denom;
+struct BaseNft;
+struct IdCollection;
+struct Owner;
+struct Collection;
+using Pagination = ::org::defi_wallet_core::Pagination;
+struct GrpcClient;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -955,10 +880,14 @@ struct GrpcClient final : public ::rust::Opaque {
   ::std::uint64_t supply(::rust::String denom_id, ::rust::String owner) const;
 
   /// Owner queries the NFTs of the specified owner
-  ::org::defi_wallet_core::Owner owner(::rust::String denom_id, ::rust::String owner, const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::org::defi_wallet_core::Owner
+  owner(::rust::String denom_id, ::rust::String owner,
+        const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// Collection queries the NFTs of the specified denom
-  ::org::defi_wallet_core::Collection collection(::rust::String denom_id, const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::org::defi_wallet_core::Collection
+  collection(::rust::String denom_id,
+             const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// Denom queries the definition of a given denom
   ::org::defi_wallet_core::Denom denom(::rust::String denom_id) const;
@@ -967,10 +896,12 @@ struct GrpcClient final : public ::rust::Opaque {
   ::org::defi_wallet_core::Denom denom_by_name(::rust::String denom_name) const;
 
   /// Denoms queries all the denoms
-  ::rust::Vec<::org::defi_wallet_core::Denom> denoms(const ::org::defi_wallet_core::Pagination &pagination) const;
+  ::rust::Vec<::org::defi_wallet_core::Denom>
+  denoms(const ::org::defi_wallet_core::Pagination &pagination) const;
 
   /// NFT queries the NFT for the given denom and token ID
-  ::org::defi_wallet_core::BaseNft nft(::rust::String denom_id, ::rust::String token_id) const;
+  ::org::defi_wallet_core::BaseNft nft(::rust::String denom_id,
+                                       ::rust::String token_id) const;
 
   ~GrpcClient() = delete;
 
@@ -983,27 +914,47 @@ private:
 };
 #endif // CXXBRIDGE1_STRUCT_org$defi_wallet_core$GrpcClient
 
-  /// creates the signed transaction
-  /// for `MsgIssueDenom` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_issue_denom_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String name, ::rust::String schema);
+/// creates the signed transaction
+/// for `MsgIssueDenom` from the Chainmain nft module
+::rust::Vec<::std::uint8_t> get_nft_issue_denom_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id,
+    ::rust::String name, ::rust::String schema);
 
-  /// creates the signed transaction
-  /// for `MsgMintNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_mint_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String name, ::rust::String uri, ::rust::String data, ::rust::String recipient);
+/// creates the signed transaction
+/// for `MsgMintNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_mint_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id,
+                       ::rust::String name, ::rust::String uri,
+                       ::rust::String data, ::rust::String recipient);
 
-  /// creates the signed transaction
-  /// for `MsgEditNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_edit_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String name, ::rust::String uri, ::rust::String data);
+/// creates the signed transaction
+/// for `MsgEditNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_edit_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id,
+                       ::rust::String name, ::rust::String uri,
+                       ::rust::String data);
 
-  /// creates the signed transaction
-  /// for `MsgTransferNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_transfer_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id, ::rust::String recipient);
+/// creates the signed transaction
+/// for `MsgTransferNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t> get_nft_transfer_signed_tx(
+    ::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+    const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id,
+    ::rust::String denom_id, ::rust::String recipient);
 
-  /// creates the signed transaction
-  /// for `MsgBurnNft` from the Chainmain nft module
-::rust::Vec<::std::uint8_t> get_nft_burn_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info, const ::org::defi_wallet_core::PrivateKey &private_key, ::rust::String id, ::rust::String denom_id);
+/// creates the signed transaction
+/// for `MsgBurnNft` from the Chainmain nft module
+::rust::Vec<::std::uint8_t>
+get_nft_burn_signed_tx(::org::defi_wallet_core::CosmosSDKTxInfoRaw tx_info,
+                       const ::org::defi_wallet_core::PrivateKey &private_key,
+                       ::rust::String id, ::rust::String denom_id);
 
-  /// Create a new grpc client
-::rust::Box<::org::defi_wallet_core::GrpcClient> new_grpc_client(::rust::String grpc_url);
+/// Create a new grpc client
+::rust::Box<::org::defi_wallet_core::GrpcClient>
+new_grpc_client(::rust::String grpc_url);
 } // namespace defi_wallet_core
 } // namespace org

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/uint.rs.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/uint.rs.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include <algorithm>
 #include <array>
@@ -21,23 +21,19 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
 class Opaque;
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -109,11 +105,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -163,8 +157,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -200,13 +193,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -215,49 +206,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -390,8 +373,7 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
@@ -405,8 +387,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -438,8 +419,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -467,38 +447,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -506,13 +478,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -523,65 +493,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -596,18 +556,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -631,8 +586,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -677,10 +631,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -719,20 +671,13 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
+template <typename T, typename = void *> struct operator_new {
   void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
@@ -742,8 +687,7 @@ struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
 };
 } // namespace detail
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit {
   T value;
   void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
   MaybeUninit() {}
@@ -758,8 +702,7 @@ struct PtrLen final {
 };
 } // namespace repr
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final {
 public:
   static Error error(repr::PtrLen repr) noexcept {
     Error error;
@@ -773,11 +716,11 @@ public:
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct U256;
-    struct U256WithOverflow;
-  }
-}
+namespace defi_wallet_core {
+struct U256;
+struct U256WithOverflow;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -790,35 +733,45 @@ struct U256 final {
   ::rust::String to_string() const noexcept;
 
   /// Addition which saturates at the maximum value.
-  ::org::defi_wallet_core::U256 saturating_add(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_add(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Subtraction which saturates at zero.
-  ::org::defi_wallet_core::U256 saturating_sub(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_sub(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Multiplication which saturates at maximum value.
-  ::org::defi_wallet_core::U256 saturating_mul(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_mul(::org::defi_wallet_core::U256 other) const noexcept;
 
-  /// Returns the addition along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_add(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the subtraction along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the multiplication along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the fast exponentiation by squaring along with a boolean indicating whether an
-  /// arithmetic overflow would occur. If an overflow would have occurred then the wrapped
+  /// Returns the addition along with a boolean indicating whether an arithmetic
+  /// overflow would occur. If an overflow would have occurred then the wrapped
   /// value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_add(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the subtraction along with a boolean indicating whether an
+  /// arithmetic overflow would occur. If an overflow would have occurred then
+  /// the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the multiplication along with a boolean indicating whether an
+  /// arithmetic overflow would occur. If an overflow would have occurred then
+  /// the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the fast exponentiation by squaring along with a boolean
+  /// indicating whether an arithmetic overflow would occur. If an overflow
+  /// would have occurred then the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Negates self in an overflowing fashion.
-  /// Returns !self + 1 using wrapping operations to return the value that represents
-  /// the negation of this unsigned value. Note that for positive unsigned values
-  /// overflow always occurs, but negating 0 does not overflow.
+  /// Returns !self + 1 using wrapping operations to return the value that
+  /// represents the negation of this unsigned value. Note that for positive
+  /// unsigned values overflow always occurs, but negating 0 does not overflow.
   ::org::defi_wallet_core::U256WithOverflow overflowing_neg() const noexcept;
 
   /// add, exception is rasided if overflow
@@ -834,15 +787,17 @@ struct U256 final {
   ::org::defi_wallet_core::U256 pow(::org::defi_wallet_core::U256 other) const;
 
   /// Negates self in an overflowing fashion.
-  /// Returns !self + 1 using wrapping operations to return the value that represents
-  /// the negation of this unsigned value.
+  /// Returns !self + 1 using wrapping operations to return the value that
+  /// represents the negation of this unsigned value.
   ::org::defi_wallet_core::U256 neg() const noexcept;
 
   /// Returns a pair `(self / other)`
-  ::org::defi_wallet_core::U256 div(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  div(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Returns a pair `(self % other)`
-  ::org::defi_wallet_core::U256 rem(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  rem(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Write to the slice in big-endian format.
   void to_big_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept;
@@ -850,8 +805,8 @@ struct U256 final {
   /// Write to the slice in little-endian format.
   void to_little_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept;
 
-  /// Format the output for the user which prefer to see values in ether (instead of wei)
-  /// Divides the input by 1e18
+  /// Format the output for the user which prefer to see values in ether
+  /// (instead of wei) Divides the input by 1e18
   ::org::defi_wallet_core::U256 format_ether() const noexcept;
 
   /// Convert to common ethereum unit types: ether, gwei, or wei
@@ -877,58 +832,116 @@ struct U256WithOverflow final {
 #endif // CXXBRIDGE1_STRUCT_org$defi_wallet_core$U256WithOverflow
 
 extern "C" {
-bool org$defi_wallet_core$cxxbridge1$U256$operator$eq(const U256 &, const U256 &) noexcept;
-bool org$defi_wallet_core$cxxbridge1$U256WithOverflow$operator$eq(const U256WithOverflow &, const U256WithOverflow &) noexcept;
+bool org$defi_wallet_core$cxxbridge1$U256$operator$eq(const U256 &,
+                                                      const U256 &) noexcept;
+bool org$defi_wallet_core$cxxbridge1$U256WithOverflow$operator$eq(
+    const U256WithOverflow &, const U256WithOverflow &) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$u256_from_dec_str(::rust::String *value, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$u256_from_dec_str(
+    ::rust::String *value, ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$u256_from_str_radix(::rust::String *txt, ::std::uint32_t radix, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$u256_from_str_radix(
+    ::rust::String *txt, ::std::uint32_t radix,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$u256_max_value() noexcept;
+::org::defi_wallet_core::U256
+org$defi_wallet_core$cxxbridge1$u256_max_value() noexcept;
 
-void org$defi_wallet_core$cxxbridge1$U256$to_string(const ::org::defi_wallet_core::U256 &self, ::rust::String *return$) noexcept;
+void org$defi_wallet_core$cxxbridge1$U256$to_string(
+    const ::org::defi_wallet_core::U256 &self,
+    ::rust::String *return$) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$saturating_add(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256
+org$defi_wallet_core$cxxbridge1$U256$saturating_add(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$saturating_sub(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256
+org$defi_wallet_core$cxxbridge1$U256$saturating_sub(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$saturating_mul(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256
+org$defi_wallet_core$cxxbridge1$U256$saturating_mul(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256WithOverflow org$defi_wallet_core$cxxbridge1$U256$overflowing_add(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256WithOverflow
+org$defi_wallet_core$cxxbridge1$U256$overflowing_add(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256WithOverflow org$defi_wallet_core$cxxbridge1$U256$overflowing_sub(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256WithOverflow
+org$defi_wallet_core$cxxbridge1$U256$overflowing_sub(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256WithOverflow org$defi_wallet_core$cxxbridge1$U256$overflowing_mul(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256WithOverflow
+org$defi_wallet_core$cxxbridge1$U256$overflowing_mul(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256WithOverflow org$defi_wallet_core$cxxbridge1$U256$overflowing_pow(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256WithOverflow
+org$defi_wallet_core$cxxbridge1$U256$overflowing_pow(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256WithOverflow org$defi_wallet_core$cxxbridge1$U256$overflowing_neg(const ::org::defi_wallet_core::U256 &self) noexcept;
+::org::defi_wallet_core::U256WithOverflow
+org$defi_wallet_core$cxxbridge1$U256$overflowing_neg(
+    const ::org::defi_wallet_core::U256 &self) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$add(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$add(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$sub(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$sub(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$mul(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$mul(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$pow(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$pow(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$neg(const ::org::defi_wallet_core::U256 &self) noexcept;
+::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$neg(
+    const ::org::defi_wallet_core::U256 &self) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$div(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$div(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$rem(const ::org::defi_wallet_core::U256 &self, ::org::defi_wallet_core::U256 other) noexcept;
+::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$rem(
+    const ::org::defi_wallet_core::U256 &self,
+    ::org::defi_wallet_core::U256 other) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$U256$to_big_endian(const ::org::defi_wallet_core::U256 &self, ::rust::Vec<::std::uint8_t> &bytes) noexcept;
+void org$defi_wallet_core$cxxbridge1$U256$to_big_endian(
+    const ::org::defi_wallet_core::U256 &self,
+    ::rust::Vec<::std::uint8_t> &bytes) noexcept;
 
-void org$defi_wallet_core$cxxbridge1$U256$to_little_endian(const ::org::defi_wallet_core::U256 &self, ::rust::Vec<::std::uint8_t> &bytes) noexcept;
+void org$defi_wallet_core$cxxbridge1$U256$to_little_endian(
+    const ::org::defi_wallet_core::U256 &self,
+    ::rust::Vec<::std::uint8_t> &bytes) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$parse_ether(::rust::String *eth, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$parse_ether(
+    ::rust::String *eth, ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$parse_units(::rust::String *amount, ::rust::String *units, ::org::defi_wallet_core::U256 *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$parse_units(
+    ::rust::String *amount, ::rust::String *units,
+    ::org::defi_wallet_core::U256 *return$) noexcept;
 
-::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$format_ether(const ::org::defi_wallet_core::U256 &self) noexcept;
+::org::defi_wallet_core::U256 org$defi_wallet_core$cxxbridge1$U256$format_ether(
+    const ::org::defi_wallet_core::U256 &self) noexcept;
 
-::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$format_units(const ::org::defi_wallet_core::U256 &self, ::rust::String *units, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen org$defi_wallet_core$cxxbridge1$U256$format_units(
+    const ::org::defi_wallet_core::U256 &self, ::rust::String *units,
+    ::rust::String *return$) noexcept;
 } // extern "C"
 
 bool U256::operator==(const U256 &rhs) const noexcept {
@@ -940,35 +953,39 @@ bool U256::operator!=(const U256 &rhs) const noexcept {
 }
 
 bool U256WithOverflow::operator==(const U256WithOverflow &rhs) const noexcept {
-  return org$defi_wallet_core$cxxbridge1$U256WithOverflow$operator$eq(*this, rhs);
+  return org$defi_wallet_core$cxxbridge1$U256WithOverflow$operator$eq(*this,
+                                                                      rhs);
 }
 
 bool U256WithOverflow::operator!=(const U256WithOverflow &rhs) const noexcept {
   return !(*this == rhs);
 }
 
-  /// Convert from a decimal string.
+/// Convert from a decimal string.
 ::org::defi_wallet_core::U256 u256(::rust::String value) {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$u256_from_dec_str(&value, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$u256_from_dec_str(&value, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Converts a string slice in a given base to an integer. Only supports radixes of 10
-  /// and 16.
+/// Converts a string slice in a given base to an integer. Only supports radixes
+/// of 10 and 16.
 ::org::defi_wallet_core::U256 u256(::rust::String txt, ::std::uint32_t radix) {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$u256_from_str_radix(&txt, radix, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$u256_from_str_radix(&txt, radix,
+                                                          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// The maximum value which can be inhabited by this type.
+/// The maximum value which can be inhabited by this type.
 ::org::defi_wallet_core::U256 u256_max_value() noexcept {
   return org$defi_wallet_core$cxxbridge1$u256_max_value();
 }
@@ -979,68 +996,84 @@ bool U256WithOverflow::operator!=(const U256WithOverflow &rhs) const noexcept {
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 U256::saturating_add(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256
+U256::saturating_add(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$saturating_add(*this, other);
 }
 
-::org::defi_wallet_core::U256 U256::saturating_sub(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256
+U256::saturating_sub(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$saturating_sub(*this, other);
 }
 
-::org::defi_wallet_core::U256 U256::saturating_mul(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256
+U256::saturating_mul(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$saturating_mul(*this, other);
 }
 
-::org::defi_wallet_core::U256WithOverflow U256::overflowing_add(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256WithOverflow
+U256::overflowing_add(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$overflowing_add(*this, other);
 }
 
-::org::defi_wallet_core::U256WithOverflow U256::overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256WithOverflow
+U256::overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$overflowing_sub(*this, other);
 }
 
-::org::defi_wallet_core::U256WithOverflow U256::overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256WithOverflow
+U256::overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$overflowing_mul(*this, other);
 }
 
-::org::defi_wallet_core::U256WithOverflow U256::overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256WithOverflow
+U256::overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$overflowing_pow(*this, other);
 }
 
-::org::defi_wallet_core::U256WithOverflow U256::overflowing_neg() const noexcept {
+::org::defi_wallet_core::U256WithOverflow
+U256::overflowing_neg() const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$overflowing_neg(*this);
 }
 
-::org::defi_wallet_core::U256 U256::add(::org::defi_wallet_core::U256 other) const {
+::org::defi_wallet_core::U256
+U256::add(::org::defi_wallet_core::U256 other) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$U256$add(*this, other, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$U256$add(*this, other, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 U256::sub(::org::defi_wallet_core::U256 other) const {
+::org::defi_wallet_core::U256
+U256::sub(::org::defi_wallet_core::U256 other) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$U256$sub(*this, other, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$U256$sub(*this, other, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 U256::mul(::org::defi_wallet_core::U256 other) const {
+::org::defi_wallet_core::U256
+U256::mul(::org::defi_wallet_core::U256 other) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$U256$mul(*this, other, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$U256$mul(*this, other, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::org::defi_wallet_core::U256 U256::pow(::org::defi_wallet_core::U256 other) const {
+::org::defi_wallet_core::U256
+U256::pow(::org::defi_wallet_core::U256 other) const {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$U256$pow(*this, other, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$U256$pow(*this, other, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1051,11 +1084,13 @@ bool U256WithOverflow::operator!=(const U256WithOverflow &rhs) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$neg(*this);
 }
 
-::org::defi_wallet_core::U256 U256::div(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256
+U256::div(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$div(*this, other);
 }
 
-::org::defi_wallet_core::U256 U256::rem(::org::defi_wallet_core::U256 other) const noexcept {
+::org::defi_wallet_core::U256
+U256::rem(::org::defi_wallet_core::U256 other) const noexcept {
   return org$defi_wallet_core$cxxbridge1$U256$rem(*this, other);
 }
 
@@ -1067,20 +1102,23 @@ void U256::to_little_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept {
   org$defi_wallet_core$cxxbridge1$U256$to_little_endian(*this, bytes);
 }
 
-  /// Converts the input to a U256 and converts from Ether to Wei.
+/// Converts the input to a U256 and converts from Ether to Wei.
 ::org::defi_wallet_core::U256 parse_ether(::rust::String eth) {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$parse_ether(&eth, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$parse_ether(&eth, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Multiplies the provided amount with 10^{units} provided.
-::org::defi_wallet_core::U256 parse_units(::rust::String amount, ::rust::String units) {
+/// Multiplies the provided amount with 10^{units} provided.
+::org::defi_wallet_core::U256 parse_units(::rust::String amount,
+                                          ::rust::String units) {
   ::rust::MaybeUninit<::org::defi_wallet_core::U256> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$parse_units(&amount, &units, &return$.value);
+  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$parse_units(
+      &amount, &units, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1093,7 +1131,9 @@ void U256::to_little_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept {
 
 ::rust::String U256::format_units(::rust::String units) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = org$defi_wallet_core$cxxbridge1$U256$format_units(*this, &units, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      org$defi_wallet_core$cxxbridge1$U256$format_units(*this, &units,
+                                                        &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/uint.rs.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/defi-wallet-core-cpp/src/uint.rs.h
@@ -18,23 +18,19 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
 class Opaque;
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -106,11 +102,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -160,8 +154,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -197,13 +190,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -212,49 +203,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -387,8 +370,7 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
@@ -402,8 +384,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -435,8 +416,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -464,38 +444,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -503,13 +475,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -520,65 +490,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -593,18 +553,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -628,8 +583,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -653,10 +607,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -695,25 +647,19 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
 } // namespace rust
 
 namespace org {
-  namespace defi_wallet_core {
-    struct U256;
-    struct U256WithOverflow;
-  }
-}
+namespace defi_wallet_core {
+struct U256;
+struct U256WithOverflow;
+} // namespace defi_wallet_core
+} // namespace org
 
 namespace org {
 namespace defi_wallet_core {
@@ -726,35 +672,45 @@ struct U256 final {
   ::rust::String to_string() const noexcept;
 
   /// Addition which saturates at the maximum value.
-  ::org::defi_wallet_core::U256 saturating_add(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_add(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Subtraction which saturates at zero.
-  ::org::defi_wallet_core::U256 saturating_sub(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_sub(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Multiplication which saturates at maximum value.
-  ::org::defi_wallet_core::U256 saturating_mul(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  saturating_mul(::org::defi_wallet_core::U256 other) const noexcept;
 
-  /// Returns the addition along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_add(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the subtraction along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the multiplication along with a boolean indicating whether an arithmetic overflow
-  /// would occur. If an overflow would have occurred then the wrapped value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept;
-
-  /// Returns the fast exponentiation by squaring along with a boolean indicating whether an
-  /// arithmetic overflow would occur. If an overflow would have occurred then the wrapped
+  /// Returns the addition along with a boolean indicating whether an arithmetic
+  /// overflow would occur. If an overflow would have occurred then the wrapped
   /// value is returned.
-  ::org::defi_wallet_core::U256WithOverflow overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_add(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the subtraction along with a boolean indicating whether an
+  /// arithmetic overflow would occur. If an overflow would have occurred then
+  /// the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_sub(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the multiplication along with a boolean indicating whether an
+  /// arithmetic overflow would occur. If an overflow would have occurred then
+  /// the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_mul(::org::defi_wallet_core::U256 other) const noexcept;
+
+  /// Returns the fast exponentiation by squaring along with a boolean
+  /// indicating whether an arithmetic overflow would occur. If an overflow
+  /// would have occurred then the wrapped value is returned.
+  ::org::defi_wallet_core::U256WithOverflow
+  overflowing_pow(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Negates self in an overflowing fashion.
-  /// Returns !self + 1 using wrapping operations to return the value that represents
-  /// the negation of this unsigned value. Note that for positive unsigned values
-  /// overflow always occurs, but negating 0 does not overflow.
+  /// Returns !self + 1 using wrapping operations to return the value that
+  /// represents the negation of this unsigned value. Note that for positive
+  /// unsigned values overflow always occurs, but negating 0 does not overflow.
   ::org::defi_wallet_core::U256WithOverflow overflowing_neg() const noexcept;
 
   /// add, exception is rasided if overflow
@@ -770,15 +726,17 @@ struct U256 final {
   ::org::defi_wallet_core::U256 pow(::org::defi_wallet_core::U256 other) const;
 
   /// Negates self in an overflowing fashion.
-  /// Returns !self + 1 using wrapping operations to return the value that represents
-  /// the negation of this unsigned value.
+  /// Returns !self + 1 using wrapping operations to return the value that
+  /// represents the negation of this unsigned value.
   ::org::defi_wallet_core::U256 neg() const noexcept;
 
   /// Returns a pair `(self / other)`
-  ::org::defi_wallet_core::U256 div(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  div(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Returns a pair `(self % other)`
-  ::org::defi_wallet_core::U256 rem(::org::defi_wallet_core::U256 other) const noexcept;
+  ::org::defi_wallet_core::U256
+  rem(::org::defi_wallet_core::U256 other) const noexcept;
 
   /// Write to the slice in big-endian format.
   void to_big_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept;
@@ -786,8 +744,8 @@ struct U256 final {
   /// Write to the slice in little-endian format.
   void to_little_endian(::rust::Vec<::std::uint8_t> &bytes) const noexcept;
 
-  /// Format the output for the user which prefer to see values in ether (instead of wei)
-  /// Divides the input by 1e18
+  /// Format the output for the user which prefer to see values in ether
+  /// (instead of wei) Divides the input by 1e18
   ::org::defi_wallet_core::U256 format_ether() const noexcept;
 
   /// Convert to common ethereum unit types: ether, gwei, or wei
@@ -812,20 +770,21 @@ struct U256WithOverflow final {
 };
 #endif // CXXBRIDGE1_STRUCT_org$defi_wallet_core$U256WithOverflow
 
-  /// Convert from a decimal string.
+/// Convert from a decimal string.
 ::org::defi_wallet_core::U256 u256(::rust::String value);
 
-  /// Converts a string slice in a given base to an integer. Only supports radixes of 10
-  /// and 16.
+/// Converts a string slice in a given base to an integer. Only supports radixes
+/// of 10 and 16.
 ::org::defi_wallet_core::U256 u256(::rust::String txt, ::std::uint32_t radix);
 
-  /// The maximum value which can be inhabited by this type.
+/// The maximum value which can be inhabited by this type.
 ::org::defi_wallet_core::U256 u256_max_value() noexcept;
 
-  /// Converts the input to a U256 and converts from Ether to Wei.
+/// Converts the input to a U256 and converts from Ether to Wei.
 ::org::defi_wallet_core::U256 parse_ether(::rust::String eth);
 
-  /// Multiplies the provided amount with 10^{units} provided.
-::org::defi_wallet_core::U256 parse_units(::rust::String amount, ::rust::String units);
+/// Multiplies the provided amount with 10^{units} provided.
+::org::defi_wallet_core::U256 parse_units(::rust::String amount,
+                                          ::rust::String units);
 } // namespace defi_wallet_core
 } // namespace org

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/extra-cpp-bindings/src/lib.rs.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/extra-cpp-bindings/src/lib.rs.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "../../walletconnectcallback.h"
 #include "../../walletconnectcallback.h"
@@ -25,21 +25,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -158,11 +154,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -212,8 +206,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -249,13 +242,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -264,49 +255,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -439,16 +422,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -469,8 +450,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -491,11 +471,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -509,36 +487,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -547,25 +520,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -577,28 +542,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -615,8 +576,7 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -648,8 +608,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -677,38 +636,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -716,13 +667,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -733,65 +682,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -806,18 +745,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -841,8 +775,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -897,10 +830,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -939,20 +870,13 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
+template <typename T, typename = void *> struct operator_new {
   void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
@@ -962,15 +886,13 @@ struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
 };
 } // namespace detail
 
-template <typename T>
-union ManuallyDrop {
+template <typename T> union ManuallyDrop {
   T value;
   ManuallyDrop(T &&value) : value(::std::move(value)) {}
   ~ManuallyDrop() {}
 };
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit {
   T value;
   void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
   MaybeUninit() {}
@@ -987,16 +909,12 @@ struct PtrLen final {
 };
 } // namespace repr
 
-template <>
-class impl<Str> final {
+template <> class impl<Str> final {
 public:
-  static repr::Fat repr(Str str) noexcept {
-    return str.repr;
-  }
+  static repr::Fat repr(Str str) noexcept { return str.repr; }
 };
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final {
 public:
   static Error error(repr::PtrLen repr) noexcept {
     Error error;
@@ -1018,29 +936,30 @@ template <> struct deleter_if<true> {
 } // namespace rust
 
 namespace com {
-  namespace crypto {
-    namespace game_sdk {
-      using WalletConnectCallback = ::com::crypto::game_sdk::WalletConnectCallback;
-      using WalletConnectSessionInfo = ::com::crypto::game_sdk::WalletConnectSessionInfo;
-      struct WalletConnectTxLegacy;
-      struct WalletConnectAddress;
-      struct WalletConnectEnsureSessionResult;
-      struct CryptoComPaymentResponse;
-      struct RawTxDetail;
-      struct RawTokenResult;
-      enum class QueryOption : ::std::uint8_t;
-      struct WalletconnectClient;
-      using OptionalArguments = ::com::crypto::game_sdk::OptionalArguments;
-    }
-  }
-}
+namespace crypto {
+namespace game_sdk {
+using WalletConnectCallback = ::com::crypto::game_sdk::WalletConnectCallback;
+using WalletConnectSessionInfo =
+    ::com::crypto::game_sdk::WalletConnectSessionInfo;
+struct WalletConnectTxLegacy;
+struct WalletConnectAddress;
+struct WalletConnectEnsureSessionResult;
+struct CryptoComPaymentResponse;
+struct RawTxDetail;
+struct RawTokenResult;
+enum class QueryOption : ::std::uint8_t;
+struct WalletconnectClient;
+using OptionalArguments = ::com::crypto::game_sdk::OptionalArguments;
+} // namespace game_sdk
+} // namespace crypto
+} // namespace com
 
 namespace com {
 namespace crypto {
 namespace game_sdk {
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectTxLegacy
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectTxLegacy
-  /// wallet connect cronos(eth) legacy-tx signing info
+/// wallet connect cronos(eth) legacy-tx signing info
 struct WalletConnectTxLegacy final {
   ::rust::String to;
   ::rust::String gas;
@@ -1055,7 +974,7 @@ struct WalletConnectTxLegacy final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectAddress
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectAddress
-  /// cronos address info
+/// cronos address info
 struct WalletConnectAddress final {
   ::std::array<::std::uint8_t, 20> address;
 
@@ -1065,7 +984,7 @@ struct WalletConnectAddress final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectEnsureSessionResult
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectEnsureSessionResult
-  /// walletconnect ensure-session result
+/// walletconnect ensure-session result
 struct WalletConnectEnsureSessionResult final {
   ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> addresses;
   ::std::uint64_t chain_id;
@@ -1076,7 +995,7 @@ struct WalletConnectEnsureSessionResult final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$CryptoComPaymentResponse
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$CryptoComPaymentResponse
-  /// the subset of payment object from https://pay-docs.crypto.com
+/// the subset of payment object from https://pay-docs.crypto.com
 struct CryptoComPaymentResponse final {
   /// uuid of the payment object
   ::rust::String id;
@@ -1103,7 +1022,8 @@ struct CryptoComPaymentResponse final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTxDetail
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTxDetail
-  /// Raw transaction details (extracted from Cronoscan/Etherscan or BlockScout API)
+/// Raw transaction details (extracted from Cronoscan/Etherscan or BlockScout
+/// API)
 struct RawTxDetail final {
   /// Transaction hash
   ::rust::String hash;
@@ -1128,7 +1048,7 @@ struct RawTxDetail final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTokenResult
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTokenResult
-  /// Token ownership result detail from BlockScout API
+/// Token ownership result detail from BlockScout API
 struct RawTokenResult final {
   /// how many tokens are owned by the address
   ::rust::String balance;
@@ -1162,14 +1082,17 @@ enum class QueryOption : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
-  /// WallnetConnect API
+/// WallnetConnect API
 struct WalletconnectClient final : public ::rust::Opaque {
   /// setup callback
-  void setup_callback(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> usercallback);
+  void setup_callback(
+      ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+          usercallback);
 
   /// create or restore a session
   /// once session is created, it will be reused
-  ::com::crypto::game_sdk::WalletConnectEnsureSessionResult ensure_session_blocking();
+  ::com::crypto::game_sdk::WalletConnectEnsureSessionResult
+  ensure_session_blocking();
 
   /// get connection string for qrcode
   ::rust::String get_connection_string();
@@ -1181,10 +1104,14 @@ struct WalletconnectClient final : public ::rust::Opaque {
   ::rust::String print_uri();
 
   /// sign message
-  ::rust::Vec<::std::uint8_t> sign_personal_blocking(::rust::String message, ::std::array<::std::uint8_t, 20> address);
+  ::rust::Vec<::std::uint8_t>
+  sign_personal_blocking(::rust::String message,
+                         ::std::array<::std::uint8_t, 20> address);
 
   /// sign cronos(eth) legacy-tx
-  ::rust::Vec<::std::uint8_t> sign_legacy_transaction_blocking(const ::com::crypto::game_sdk::WalletConnectTxLegacy &info, ::std::array<::std::uint8_t, 20> address);
+  ::rust::Vec<::std::uint8_t> sign_legacy_transaction_blocking(
+      const ::com::crypto::game_sdk::WalletConnectTxLegacy &info,
+      ::std::array<::std::uint8_t, 20> address);
 
   ~WalletconnectClient() = delete;
 
@@ -1198,154 +1125,302 @@ private:
 #endif // CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
 
 extern "C" {
-void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onConnected(const ::com::crypto::game_sdk::WalletConnectCallback &self, const ::com::crypto::game_sdk::WalletConnectSessionInfo &sessioninfo) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectCallback::*onConnected$)(const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const = &::com::crypto::game_sdk::WalletConnectCallback::onConnected;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onConnected(
+    const ::com::crypto::game_sdk::WalletConnectCallback &self,
+    const ::com::crypto::game_sdk::WalletConnectSessionInfo
+        &sessioninfo) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectCallback::*onConnected$)(
+      const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const =
+      &::com::crypto::game_sdk::WalletConnectCallback::onConnected;
   (self.*onConnected$)(sessioninfo);
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onDisconnected(const ::com::crypto::game_sdk::WalletConnectCallback &self, const ::com::crypto::game_sdk::WalletConnectSessionInfo &sessioninfo) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectCallback::*onDisconnected$)(const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const = &::com::crypto::game_sdk::WalletConnectCallback::onDisconnected;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onDisconnected(
+    const ::com::crypto::game_sdk::WalletConnectCallback &self,
+    const ::com::crypto::game_sdk::WalletConnectSessionInfo
+        &sessioninfo) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectCallback::*onDisconnected$)(
+      const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const =
+      &::com::crypto::game_sdk::WalletConnectCallback::onDisconnected;
   (self.*onDisconnected$)(sessioninfo);
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onConnecting(const ::com::crypto::game_sdk::WalletConnectCallback &self, const ::com::crypto::game_sdk::WalletConnectSessionInfo &sessioninfo) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectCallback::*onConnecting$)(const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const = &::com::crypto::game_sdk::WalletConnectCallback::onConnecting;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onConnecting(
+    const ::com::crypto::game_sdk::WalletConnectCallback &self,
+    const ::com::crypto::game_sdk::WalletConnectSessionInfo
+        &sessioninfo) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectCallback::*onConnecting$)(
+      const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const =
+      &::com::crypto::game_sdk::WalletConnectCallback::onConnecting;
   (self.*onConnecting$)(sessioninfo);
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onUpdated(const ::com::crypto::game_sdk::WalletConnectCallback &self, const ::com::crypto::game_sdk::WalletConnectSessionInfo &sessioninfo) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectCallback::*onUpdated$)(const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const = &::com::crypto::game_sdk::WalletConnectCallback::onUpdated;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectCallback$onUpdated(
+    const ::com::crypto::game_sdk::WalletConnectCallback &self,
+    const ::com::crypto::game_sdk::WalletConnectSessionInfo
+        &sessioninfo) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectCallback::*onUpdated$)(
+      const ::com::crypto::game_sdk::WalletConnectSessionInfo &) const =
+      &::com::crypto::game_sdk::WalletConnectCallback::onUpdated;
   (self.*onUpdated$)(sessioninfo);
 }
 
-::com::crypto::game_sdk::WalletConnectSessionInfo *com$crypto$game_sdk$cxxbridge1$new_walletconnect_sessioninfo() noexcept {
-  ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> (*new_walletconnect_sessioninfo$)() = ::com::crypto::game_sdk::new_walletconnect_sessioninfo;
+::com::crypto::game_sdk::WalletConnectSessionInfo *
+com$crypto$game_sdk$cxxbridge1$new_walletconnect_sessioninfo() noexcept {
+  ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> (
+      *new_walletconnect_sessioninfo$)() =
+      ::com::crypto::game_sdk::new_walletconnect_sessioninfo;
   return new_walletconnect_sessioninfo$().release();
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_chainid(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *chainid) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_chainid$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_chainid;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_chainid(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *chainid) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_chainid$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_chainid;
   (self.*set_chainid$)(::rust::String(::rust::unsafe_bitcopy, *chainid));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_connected(::com::crypto::game_sdk::WalletConnectSessionInfo &self, bool connected) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_connected$)(bool) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_connected;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_connected(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    bool connected) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_connected$)(
+      bool) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_connected;
   (self.*set_connected$)(connected);
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_accounts(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::Vec<::rust::String> *accounts) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_accounts$)(::rust::Vec<::rust::String>) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_accounts;
-  (self.*set_accounts$)(::rust::Vec<::rust::String>(::rust::unsafe_bitcopy, *accounts));
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_accounts(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::Vec<::rust::String> *accounts) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_accounts$)(
+      ::rust::Vec<::rust::String>) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_accounts;
+  (self.*set_accounts$)(
+      ::rust::Vec<::rust::String>(::rust::unsafe_bitcopy, *accounts));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_bridge(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *bridge) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_bridge$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_bridge;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_bridge(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *bridge) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_bridge$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_bridge;
   (self.*set_bridge$)(::rust::String(::rust::unsafe_bitcopy, *bridge));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_key(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *key) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_key$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_key;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_key(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *key) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_key$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_key;
   (self.*set_key$)(::rust::String(::rust::unsafe_bitcopy, *key));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_clientid(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *clientid) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_clientid$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_clientid;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_clientid(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *clientid) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_clientid$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_clientid;
   (self.*set_clientid$)(::rust::String(::rust::unsafe_bitcopy, *clientid));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_clientmeta(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *clientmeta) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_clientmeta$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_clientmeta;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_clientmeta(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *clientmeta) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_clientmeta$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_clientmeta;
   (self.*set_clientmeta$)(::rust::String(::rust::unsafe_bitcopy, *clientmeta));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_peerid(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *peerid) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_peerid$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_peerid;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_peerid(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *peerid) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_peerid$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_peerid;
   (self.*set_peerid$)(::rust::String(::rust::unsafe_bitcopy, *peerid));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_peermeta(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *peermeta) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_peermeta$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_peermeta;
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_peermeta(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *peermeta) noexcept {
+  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_peermeta$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_peermeta;
   (self.*set_peermeta$)(::rust::String(::rust::unsafe_bitcopy, *peermeta));
 }
 
-void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_handshaketopic(::com::crypto::game_sdk::WalletConnectSessionInfo &self, const ::rust::String *handshaketopic) noexcept {
-  void (::com::crypto::game_sdk::WalletConnectSessionInfo::*set_handshaketopic$)(::rust::String) = &::com::crypto::game_sdk::WalletConnectSessionInfo::set_handshaketopic;
-  (self.*set_handshaketopic$)(::rust::String(::rust::unsafe_bitcopy, *handshaketopic));
+void com$crypto$game_sdk$cxxbridge1$WalletConnectSessionInfo$set_handshaketopic(
+    ::com::crypto::game_sdk::WalletConnectSessionInfo &self,
+    const ::rust::String *handshaketopic) noexcept {
+  void (
+      ::com::crypto::game_sdk::WalletConnectSessionInfo::*set_handshaketopic$)(
+      ::rust::String) =
+      &::com::crypto::game_sdk::WalletConnectSessionInfo::set_handshaketopic;
+  (self.*set_handshaketopic$)(
+      ::rust::String(::rust::unsafe_bitcopy, *handshaketopic));
 }
-bool com$crypto$game_sdk$cxxbridge1$RawTxDetail$operator$eq(const RawTxDetail &, const RawTxDetail &) noexcept;
-bool com$crypto$game_sdk$cxxbridge1$RawTokenResult$operator$eq(const RawTokenResult &, const RawTokenResult &) noexcept;
-::std::size_t com$crypto$game_sdk$cxxbridge1$WalletconnectClient$operator$sizeof() noexcept;
-::std::size_t com$crypto$game_sdk$cxxbridge1$WalletconnectClient$operator$alignof() noexcept;
+bool com$crypto$game_sdk$cxxbridge1$RawTxDetail$operator$eq(
+    const RawTxDetail &, const RawTxDetail &) noexcept;
+bool com$crypto$game_sdk$cxxbridge1$RawTokenResult$operator$eq(
+    const RawTokenResult &, const RawTokenResult &) noexcept;
+::std::size_t
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$operator$sizeof() noexcept;
+::std::size_t
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$operator$alignof() noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$walletconnect_restore_client(::rust::String *session_info, ::rust::Box<::com::crypto::game_sdk::WalletconnectClient> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$walletconnect_restore_client(
+    ::rust::String *session_info,
+    ::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+        *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$walletconnect_new_client(::rust::String *description, ::rust::String *url, ::rust::Vec<::rust::String> *icon_urls, ::rust::String *name, ::rust::Box<::com::crypto::game_sdk::WalletconnectClient> *return$) noexcept;
+::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$walletconnect_new_client(
+    ::rust::String *description, ::rust::String *url,
+    ::rust::Vec<::rust::String> *icon_urls, ::rust::String *name,
+    ::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+        *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$setup_callback(::com::crypto::game_sdk::WalletconnectClient &self, ::com::crypto::game_sdk::WalletConnectCallback *usercallback) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$setup_callback(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    ::com::crypto::game_sdk::WalletConnectCallback *usercallback) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$ensure_session_blocking(::com::crypto::game_sdk::WalletconnectClient &self, ::com::crypto::game_sdk::WalletConnectEnsureSessionResult *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$ensure_session_blocking(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    ::com::crypto::game_sdk::WalletConnectEnsureSessionResult
+        *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$get_connection_string(::com::crypto::game_sdk::WalletconnectClient &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$get_connection_string(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$save_client(::com::crypto::game_sdk::WalletconnectClient &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$save_client(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$print_uri(::com::crypto::game_sdk::WalletconnectClient &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$print_uri(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_personal_blocking(::com::crypto::game_sdk::WalletconnectClient &self, ::rust::String *message, ::std::array<::std::uint8_t, 20> *address, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_personal_blocking(
+    ::com::crypto::game_sdk::WalletconnectClient &self, ::rust::String *message,
+    ::std::array<::std::uint8_t, 20> *address,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_legacy_transaction_blocking(::com::crypto::game_sdk::WalletconnectClient &self, const ::com::crypto::game_sdk::WalletConnectTxLegacy &info, ::std::array<::std::uint8_t, 20> *address, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_legacy_transaction_blocking(
+    ::com::crypto::game_sdk::WalletconnectClient &self,
+    const ::com::crypto::game_sdk::WalletConnectTxLegacy &info,
+    ::std::array<::std::uint8_t, 20> *address,
+    ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_transaction_history_blocking(::rust::String *address, ::rust::String *api_key, ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$get_transaction_history_blocking(
+    ::rust::String *address, ::rust::String *api_key,
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_erc20_transfer_history_blocking(::rust::String *address, ::rust::String *contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String *api_key, ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$get_erc20_transfer_history_blocking(
+    ::rust::String *address, ::rust::String *contract_address,
+    ::com::crypto::game_sdk::QueryOption option, ::rust::String *api_key,
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_erc721_transfer_history_blocking(::rust::String *address, ::rust::String *contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String *api_key, ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$get_erc721_transfer_history_blocking(
+    ::rust::String *address, ::rust::String *contract_address,
+    ::com::crypto::game_sdk::QueryOption option, ::rust::String *api_key,
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_tokens_blocking(::rust::String *blockscout_base_url, ::rust::String *account_address, ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *return$) noexcept;
+::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_tokens_blocking(
+    ::rust::String *blockscout_base_url, ::rust::String *account_address,
+    ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_token_transfers_blocking(::rust::String *blockscout_base_url, ::rust::String *address, ::rust::String *contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
+::rust::repr::PtrLen
+com$crypto$game_sdk$cxxbridge1$get_token_transfers_blocking(
+    ::rust::String *blockscout_base_url, ::rust::String *address,
+    ::rust::String *contract_address,
+    ::com::crypto::game_sdk::QueryOption option,
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$create_payment(::rust::String *secret_or_publishable_api_key, ::rust::String *base_unit_amount, ::rust::String *currency, const ::com::crypto::game_sdk::OptionalArguments &optional_args, ::com::crypto::game_sdk::CryptoComPaymentResponse *return$) noexcept;
+::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$create_payment(
+    ::rust::String *secret_or_publishable_api_key,
+    ::rust::String *base_unit_amount, ::rust::String *currency,
+    const ::com::crypto::game_sdk::OptionalArguments &optional_args,
+    ::com::crypto::game_sdk::CryptoComPaymentResponse *return$) noexcept;
 
-::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_payment(::rust::String *secret_or_publishable_api_key, ::rust::String *payment_id, ::com::crypto::game_sdk::CryptoComPaymentResponse *return$) noexcept;
+::rust::repr::PtrLen com$crypto$game_sdk$cxxbridge1$get_payment(
+    ::rust::String *secret_or_publishable_api_key, ::rust::String *payment_id,
+    ::com::crypto::game_sdk::CryptoComPaymentResponse *return$) noexcept;
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_description(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_description$)() const = &::com::crypto::game_sdk::OptionalArguments::get_description;
+::rust::repr::Fat
+com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_description(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_description$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_description;
   return ::rust::impl<::rust::Str>::repr((self.*get_description$)());
 }
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_metadata(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_metadata$)() const = &::com::crypto::game_sdk::OptionalArguments::get_metadata;
+::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_metadata(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_metadata$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_metadata;
   return ::rust::impl<::rust::Str>::repr((self.*get_metadata$)());
 }
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_order_id(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_order_id$)() const = &::com::crypto::game_sdk::OptionalArguments::get_order_id;
+::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_order_id(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_order_id$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_order_id;
   return ::rust::impl<::rust::Str>::repr((self.*get_order_id$)());
 }
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_return_url(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_return_url$)() const = &::com::crypto::game_sdk::OptionalArguments::get_return_url;
+::rust::repr::Fat
+com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_return_url(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_return_url$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_return_url;
   return ::rust::impl<::rust::Str>::repr((self.*get_return_url$)());
 }
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_cancel_url(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_cancel_url$)() const = &::com::crypto::game_sdk::OptionalArguments::get_cancel_url;
+::rust::repr::Fat
+com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_cancel_url(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_cancel_url$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_cancel_url;
   return ::rust::impl<::rust::Str>::repr((self.*get_cancel_url$)());
 }
 
-::rust::repr::Fat com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_sub_merchant_id(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::rust::Str (::com::crypto::game_sdk::OptionalArguments::*get_sub_merchant_id$)() const = &::com::crypto::game_sdk::OptionalArguments::get_sub_merchant_id;
+::rust::repr::Fat
+com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_sub_merchant_id(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::rust::Str (
+      ::com::crypto::game_sdk::OptionalArguments::*get_sub_merchant_id$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_sub_merchant_id;
   return ::rust::impl<::rust::Str>::repr((self.*get_sub_merchant_id$)());
 }
 
-bool com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_onchain_allowed(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  bool (::com::crypto::game_sdk::OptionalArguments::*get_onchain_allowed$)() const = &::com::crypto::game_sdk::OptionalArguments::get_onchain_allowed;
+bool com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_onchain_allowed(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  bool (::com::crypto::game_sdk::OptionalArguments::*get_onchain_allowed$)()
+      const = &::com::crypto::game_sdk::OptionalArguments::get_onchain_allowed;
   return (self.*get_onchain_allowed$)();
 }
 
-::std::uint64_t com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_expired_at(const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
-  ::std::uint64_t (::com::crypto::game_sdk::OptionalArguments::*get_expired_at$)() const = &::com::crypto::game_sdk::OptionalArguments::get_expired_at;
+::std::uint64_t com$crypto$game_sdk$cxxbridge1$OptionalArguments$get_expired_at(
+    const ::com::crypto::game_sdk::OptionalArguments &self) noexcept {
+  ::std::uint64_t (
+      ::com::crypto::game_sdk::OptionalArguments::*get_expired_at$)() const =
+      &::com::crypto::game_sdk::OptionalArguments::get_expired_at;
   return (self.*get_expired_at$)();
 }
 } // extern "C"
@@ -1374,37 +1449,56 @@ bool RawTokenResult::operator!=(const RawTokenResult &rhs) const noexcept {
   return com$crypto$game_sdk$cxxbridge1$WalletconnectClient$operator$alignof();
 }
 
-  /// restore walletconnect-session from string
-::rust::Box<::com::crypto::game_sdk::WalletconnectClient> walletconnect_restore_client(::rust::String session_info) {
-  ::rust::MaybeUninit<::rust::Box<::com::crypto::game_sdk::WalletconnectClient>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$walletconnect_restore_client(&session_info, &return$.value);
+/// restore walletconnect-session from string
+::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+walletconnect_restore_client(::rust::String session_info) {
+  ::rust::MaybeUninit<::rust::Box<::com::crypto::game_sdk::WalletconnectClient>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$walletconnect_restore_client(
+          &session_info, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// create walletconnect-session
-::rust::Box<::com::crypto::game_sdk::WalletconnectClient> walletconnect_new_client(::rust::String description, ::rust::String url, ::rust::Vec<::rust::String> icon_urls, ::rust::String name) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> icon_urls$(::std::move(icon_urls));
-  ::rust::MaybeUninit<::rust::Box<::com::crypto::game_sdk::WalletconnectClient>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$walletconnect_new_client(&description, &url, &icon_urls$.value, &name, &return$.value);
+/// create walletconnect-session
+::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+walletconnect_new_client(::rust::String description, ::rust::String url,
+                         ::rust::Vec<::rust::String> icon_urls,
+                         ::rust::String name) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> icon_urls$(
+      ::std::move(icon_urls));
+  ::rust::MaybeUninit<::rust::Box<::com::crypto::game_sdk::WalletconnectClient>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$walletconnect_new_client(
+          &description, &url, &icon_urls$.value, &name, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-void WalletconnectClient::setup_callback(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> usercallback) {
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$setup_callback(*this, usercallback.release());
+void WalletconnectClient::setup_callback(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+        usercallback) {
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$setup_callback(
+          *this, usercallback.release());
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
 }
 
-::com::crypto::game_sdk::WalletConnectEnsureSessionResult WalletconnectClient::ensure_session_blocking() {
-  ::rust::MaybeUninit<::com::crypto::game_sdk::WalletConnectEnsureSessionResult> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$ensure_session_blocking(*this, &return$.value);
+::com::crypto::game_sdk::WalletConnectEnsureSessionResult
+WalletconnectClient::ensure_session_blocking() {
+  ::rust::MaybeUninit<::com::crypto::game_sdk::WalletConnectEnsureSessionResult>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$ensure_session_blocking(
+          *this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1413,7 +1507,9 @@ void WalletconnectClient::setup_callback(::std::unique_ptr<::com::crypto::game_s
 
 ::rust::String WalletconnectClient::get_connection_string() {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$get_connection_string(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$get_connection_string(
+          *this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1422,7 +1518,9 @@ void WalletconnectClient::setup_callback(::std::unique_ptr<::com::crypto::game_s
 
 ::rust::String WalletconnectClient::save_client() {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$save_client(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$save_client(
+          *this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1431,93 +1529,146 @@ void WalletconnectClient::setup_callback(::std::unique_ptr<::com::crypto::game_s
 
 ::rust::String WalletconnectClient::print_uri() {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$print_uri(*this, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$print_uri(
+          *this, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::std::uint8_t> WalletconnectClient::sign_personal_blocking(::rust::String message, ::std::array<::std::uint8_t, 20> address) {
-  ::rust::ManuallyDrop<::std::array<::std::uint8_t, 20>> address$(::std::move(address));
+::rust::Vec<::std::uint8_t> WalletconnectClient::sign_personal_blocking(
+    ::rust::String message, ::std::array<::std::uint8_t, 20> address) {
+  ::rust::ManuallyDrop<::std::array<::std::uint8_t, 20>> address$(
+      ::std::move(address));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_personal_blocking(*this, &message, &address$.value, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_personal_blocking(
+          *this, &message, &address$.value, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::std::uint8_t> WalletconnectClient::sign_legacy_transaction_blocking(const ::com::crypto::game_sdk::WalletConnectTxLegacy &info, ::std::array<::std::uint8_t, 20> address) {
-  ::rust::ManuallyDrop<::std::array<::std::uint8_t, 20>> address$(::std::move(address));
+::rust::Vec<::std::uint8_t>
+WalletconnectClient::sign_legacy_transaction_blocking(
+    const ::com::crypto::game_sdk::WalletConnectTxLegacy &info,
+    ::std::array<::std::uint8_t, 20> address) {
+  ::rust::ManuallyDrop<::std::array<::std::uint8_t, 20>> address$(
+      ::std::move(address));
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_legacy_transaction_blocking(*this, info, &address$.value, &return$.value);
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$WalletconnectClient$sign_legacy_transaction_blocking(
+          *this, info, &address$.value, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Etherscan API
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_transaction_history_blocking(::rust::String address, ::rust::String api_key) {
-  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_transaction_history_blocking(&address, &api_key, &return$.value);
+/// Etherscan API
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_transaction_history_blocking(::rust::String address,
+                                 ::rust::String api_key) {
+  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$get_transaction_history_blocking(
+          &address, &api_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_erc20_transfer_history_blocking(::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key) {
-  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_erc20_transfer_history_blocking(&address, &contract_address, option, &api_key, &return$.value);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_erc20_transfer_history_blocking(::rust::String address,
+                                    ::rust::String contract_address,
+                                    ::com::crypto::game_sdk::QueryOption option,
+                                    ::rust::String api_key) {
+  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$get_erc20_transfer_history_blocking(
+          &address, &contract_address, option, &api_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_erc721_transfer_history_blocking(::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key) {
-  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_erc721_transfer_history_blocking(&address, &contract_address, option, &api_key, &return$.value);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_erc721_transfer_history_blocking(
+    ::rust::String address, ::rust::String contract_address,
+    ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key) {
+  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$get_erc721_transfer_history_blocking(
+          &address, &contract_address, option, &api_key, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// BlockScout API
-::rust::Vec<::com::crypto::game_sdk::RawTokenResult> get_tokens_blocking(::rust::String blockscout_base_url, ::rust::String account_address) {
-  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTokenResult>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_tokens_blocking(&blockscout_base_url, &account_address, &return$.value);
+/// BlockScout API
+::rust::Vec<::com::crypto::game_sdk::RawTokenResult>
+get_tokens_blocking(::rust::String blockscout_base_url,
+                    ::rust::String account_address) {
+  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTokenResult>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$get_tokens_blocking(
+          &blockscout_base_url, &account_address, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_token_transfers_blocking(::rust::String blockscout_base_url, ::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option) {
-  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_token_transfers_blocking(&blockscout_base_url, &address, &contract_address, option, &return$.value);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_token_transfers_blocking(::rust::String blockscout_base_url,
+                             ::rust::String address,
+                             ::rust::String contract_address,
+                             ::com::crypto::game_sdk::QueryOption option) {
+  ::rust::MaybeUninit<::rust::Vec<::com::crypto::game_sdk::RawTxDetail>>
+      return$;
+  ::rust::repr::PtrLen error$ =
+      com$crypto$game_sdk$cxxbridge1$get_token_transfers_blocking(
+          &blockscout_base_url, &address, &contract_address, option,
+          &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-  /// Crypto.com Pay API
-::com::crypto::game_sdk::CryptoComPaymentResponse create_payment(::rust::String secret_or_publishable_api_key, ::rust::String base_unit_amount, ::rust::String currency, const ::com::crypto::game_sdk::OptionalArguments &optional_args) {
-  ::rust::MaybeUninit<::com::crypto::game_sdk::CryptoComPaymentResponse> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$create_payment(&secret_or_publishable_api_key, &base_unit_amount, &currency, optional_args, &return$.value);
+/// Crypto.com Pay API
+::com::crypto::game_sdk::CryptoComPaymentResponse create_payment(
+    ::rust::String secret_or_publishable_api_key,
+    ::rust::String base_unit_amount, ::rust::String currency,
+    const ::com::crypto::game_sdk::OptionalArguments &optional_args) {
+  ::rust::MaybeUninit<::com::crypto::game_sdk::CryptoComPaymentResponse>
+      return$;
+  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$create_payment(
+      &secret_or_publishable_api_key, &base_unit_amount, &currency,
+      optional_args, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
   return ::std::move(return$.value);
 }
 
-::com::crypto::game_sdk::CryptoComPaymentResponse get_payment(::rust::String secret_or_publishable_api_key, ::rust::String payment_id) {
-  ::rust::MaybeUninit<::com::crypto::game_sdk::CryptoComPaymentResponse> return$;
-  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_payment(&secret_or_publishable_api_key, &payment_id, &return$.value);
+::com::crypto::game_sdk::CryptoComPaymentResponse
+get_payment(::rust::String secret_or_publishable_api_key,
+            ::rust::String payment_id) {
+  ::rust::MaybeUninit<::com::crypto::game_sdk::CryptoComPaymentResponse>
+      return$;
+  ::rust::repr::PtrLen error$ = com$crypto$game_sdk$cxxbridge1$get_payment(
+      &secret_or_publishable_api_key, &payment_id, &return$.value);
   if (error$.ptr) {
     throw ::rust::impl<::rust::Error>::error(error$);
   }
@@ -1528,128 +1679,233 @@ void WalletconnectClient::setup_callback(::std::unique_ptr<::com::crypto::game_s
 } // namespace com
 
 extern "C" {
-static_assert(::rust::detail::is_complete<::com::crypto::game_sdk::WalletConnectSessionInfo>::value, "definition of WalletConnectSessionInfo is required");
-static_assert(sizeof(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$null(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>();
+static_assert(::rust::detail::is_complete<
+                  ::com::crypto::game_sdk::WalletConnectSessionInfo>::value,
+              "definition of WalletConnectSessionInfo is required");
+static_assert(
+    sizeof(
+        ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>) ==
+        sizeof(void *),
+    "");
+static_assert(
+    alignof(
+        ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>) ==
+        alignof(void *),
+    "");
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$null(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>
+        *ptr) noexcept {
+  ::new (ptr)::std::unique_ptr<
+      ::com::crypto::game_sdk::WalletConnectSessionInfo>();
 }
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$raw(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> *ptr, ::com::crypto::game_sdk::WalletConnectSessionInfo *raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>(raw);
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$raw(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> *ptr,
+    ::com::crypto::game_sdk::WalletConnectSessionInfo *raw) noexcept {
+  ::new (ptr)::std::unique_ptr<
+      ::com::crypto::game_sdk::WalletConnectSessionInfo>(raw);
 }
-const ::com::crypto::game_sdk::WalletConnectSessionInfo *cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$get(const ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>& ptr) noexcept {
+const ::com::crypto::game_sdk::WalletConnectSessionInfo *
+cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$get(
+    const ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>
+        &ptr) noexcept {
   return ptr.get();
 }
-::com::crypto::game_sdk::WalletConnectSessionInfo *cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$release(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>& ptr) noexcept {
+::com::crypto::game_sdk::WalletConnectSessionInfo *
+cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$release(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>
+        &ptr) noexcept {
   return ptr.release();
 }
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$drop(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::com::crypto::game_sdk::WalletConnectSessionInfo>::value>{}(ptr);
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectSessionInfo$drop(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectSessionInfo>
+        *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<
+      ::com::crypto::game_sdk::WalletConnectSessionInfo>::value>{}(ptr);
 }
 
-void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$new(const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$drop(::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$len(const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$capacity(const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
-const ::com::crypto::game_sdk::WalletConnectAddress *cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$data(const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$reserve_total(::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$set_len(::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$truncate(::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$new(
+    const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress>
+        *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$drop(
+    ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$len(
+    const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress>
+        *ptr) noexcept;
+::std::size_t
+cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$capacity(
+    const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress>
+        *ptr) noexcept;
+const ::com::crypto::game_sdk::WalletConnectAddress *
+cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$data(
+    const ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress>
+        *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$reserve_total(
+    ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$set_len(
+    ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$truncate(
+    ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> *ptr,
+    ::std::size_t len) noexcept;
 
-::com::crypto::game_sdk::WalletconnectClient *cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$alloc() noexcept;
-void cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$dealloc(::com::crypto::game_sdk::WalletconnectClient *) noexcept;
-void cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$drop(::rust::Box<::com::crypto::game_sdk::WalletconnectClient> *ptr) noexcept;
+::com::crypto::game_sdk::WalletconnectClient *
+cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$alloc() noexcept;
+void cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$dealloc(
+    ::com::crypto::game_sdk::WalletconnectClient *) noexcept;
+void cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$drop(
+    ::rust::Box<::com::crypto::game_sdk::WalletconnectClient> *ptr) noexcept;
 
-static_assert(::rust::detail::is_complete<::com::crypto::game_sdk::WalletConnectCallback>::value, "definition of WalletConnectCallback is required");
-static_assert(sizeof(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$null(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>();
+static_assert(::rust::detail::is_complete<
+                  ::com::crypto::game_sdk::WalletConnectCallback>::value,
+              "definition of WalletConnectCallback is required");
+static_assert(
+    sizeof(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>) ==
+        sizeof(void *),
+    "");
+static_assert(
+    alignof(
+        ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>) ==
+        alignof(void *),
+    "");
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$null(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+        *ptr) noexcept {
+  ::new (
+      ptr)::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>();
 }
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$raw(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> *ptr, ::com::crypto::game_sdk::WalletConnectCallback *raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>(raw);
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$raw(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> *ptr,
+    ::com::crypto::game_sdk::WalletConnectCallback *raw) noexcept {
+  ::new (ptr)::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>(
+      raw);
 }
-const ::com::crypto::game_sdk::WalletConnectCallback *cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$get(const ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>& ptr) noexcept {
+const ::com::crypto::game_sdk::WalletConnectCallback *
+cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$get(
+    const ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+        &ptr) noexcept {
   return ptr.get();
 }
-::com::crypto::game_sdk::WalletConnectCallback *cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$release(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>& ptr) noexcept {
+::com::crypto::game_sdk::WalletConnectCallback *
+cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$release(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+        &ptr) noexcept {
   return ptr.release();
 }
-void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$drop(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::com::crypto::game_sdk::WalletConnectCallback>::value>{}(ptr);
+void cxxbridge1$unique_ptr$com$crypto$game_sdk$WalletConnectCallback$drop(
+    ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+        *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<
+      ::com::crypto::game_sdk::WalletConnectCallback>::value>{}(ptr);
 }
 
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$new(const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$drop(::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$len(const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$capacity(const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
-const ::com::crypto::game_sdk::RawTxDetail *cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$data(const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$reserve_total(::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$set_len(::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$truncate(::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$new(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$drop(
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$len(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$capacity(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
+const ::com::crypto::game_sdk::RawTxDetail *
+cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$data(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$reserve_total(
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$set_len(
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$truncate(
+    ::rust::Vec<::com::crypto::game_sdk::RawTxDetail> *ptr,
+    ::std::size_t len) noexcept;
 
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$new(const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$drop(::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$len(const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$capacity(const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
-const ::com::crypto::game_sdk::RawTokenResult *cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$data(const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$reserve_total(::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$set_len(::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$truncate(::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$new(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$drop(
+    ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$len(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$capacity(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
+const ::com::crypto::game_sdk::RawTokenResult *
+cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$data(
+    const ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$reserve_total(
+    ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr,
+    ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$set_len(
+    ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr,
+    ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$truncate(
+    ::rust::Vec<::com::crypto::game_sdk::RawTokenResult> *ptr,
+    ::std::size_t len) noexcept;
 } // extern "C"
 
 namespace rust {
 inline namespace cxxbridge1 {
-template <>
-Vec<::com::crypto::game_sdk::WalletConnectAddress>::Vec() noexcept {
+template <> Vec<::com::crypto::game_sdk::WalletConnectAddress>::Vec() noexcept {
   cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$new(this);
 }
 template <>
 void Vec<::com::crypto::game_sdk::WalletConnectAddress>::drop() noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$drop(this);
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$drop(
+      this);
 }
 template <>
-::std::size_t Vec<::com::crypto::game_sdk::WalletConnectAddress>::size() const noexcept {
+::std::size_t
+Vec<::com::crypto::game_sdk::WalletConnectAddress>::size() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$len(this);
 }
 template <>
-::std::size_t Vec<::com::crypto::game_sdk::WalletConnectAddress>::capacity() const noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$capacity(this);
+::std::size_t
+Vec<::com::crypto::game_sdk::WalletConnectAddress>::capacity() const noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$capacity(
+      this);
 }
 template <>
-const ::com::crypto::game_sdk::WalletConnectAddress *Vec<::com::crypto::game_sdk::WalletConnectAddress>::data() const noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$data(this);
+const ::com::crypto::game_sdk::WalletConnectAddress *
+Vec<::com::crypto::game_sdk::WalletConnectAddress>::data() const noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$data(
+      this);
 }
 template <>
-void Vec<::com::crypto::game_sdk::WalletConnectAddress>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$reserve_total(this, new_cap);
+void Vec<::com::crypto::game_sdk::WalletConnectAddress>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$reserve_total(
+      this, new_cap);
 }
 template <>
-void Vec<::com::crypto::game_sdk::WalletConnectAddress>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$set_len(this, len);
+void Vec<::com::crypto::game_sdk::WalletConnectAddress>::set_len(
+    ::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$set_len(
+      this, len);
 }
 template <>
-void Vec<::com::crypto::game_sdk::WalletConnectAddress>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$truncate(this, len);
+void Vec<::com::crypto::game_sdk::WalletConnectAddress>::truncate(
+    ::std::size_t len) {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$WalletConnectAddress$truncate(
+      this, len);
 }
 template <>
-::com::crypto::game_sdk::WalletconnectClient *Box<::com::crypto::game_sdk::WalletconnectClient>::allocation::alloc() noexcept {
+::com::crypto::game_sdk::WalletconnectClient *
+Box<::com::crypto::game_sdk::WalletconnectClient>::allocation::
+    alloc() noexcept {
   return cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$alloc();
 }
 template <>
-void Box<::com::crypto::game_sdk::WalletconnectClient>::allocation::dealloc(::com::crypto::game_sdk::WalletconnectClient *ptr) noexcept {
+void Box<::com::crypto::game_sdk::WalletconnectClient>::allocation::dealloc(
+    ::com::crypto::game_sdk::WalletconnectClient *ptr) noexcept {
   cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$dealloc(ptr);
 }
 template <>
 void Box<::com::crypto::game_sdk::WalletconnectClient>::drop() noexcept {
   cxxbridge1$box$com$crypto$game_sdk$WalletconnectClient$drop(this);
 }
-template <>
-Vec<::com::crypto::game_sdk::RawTxDetail>::Vec() noexcept {
+template <> Vec<::com::crypto::game_sdk::RawTxDetail>::Vec() noexcept {
   cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$new(this);
 }
-template <>
-void Vec<::com::crypto::game_sdk::RawTxDetail>::drop() noexcept {
+template <> void Vec<::com::crypto::game_sdk::RawTxDetail>::drop() noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$drop(this);
 }
 template <>
@@ -1657,56 +1913,68 @@ template <>
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$len(this);
 }
 template <>
-::std::size_t Vec<::com::crypto::game_sdk::RawTxDetail>::capacity() const noexcept {
+::std::size_t
+Vec<::com::crypto::game_sdk::RawTxDetail>::capacity() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$capacity(this);
 }
 template <>
-const ::com::crypto::game_sdk::RawTxDetail *Vec<::com::crypto::game_sdk::RawTxDetail>::data() const noexcept {
+const ::com::crypto::game_sdk::RawTxDetail *
+Vec<::com::crypto::game_sdk::RawTxDetail>::data() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$data(this);
 }
 template <>
-void Vec<::com::crypto::game_sdk::RawTxDetail>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$reserve_total(this, new_cap);
+void Vec<::com::crypto::game_sdk::RawTxDetail>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$reserve_total(
+      this, new_cap);
 }
 template <>
-void Vec<::com::crypto::game_sdk::RawTxDetail>::set_len(::std::size_t len) noexcept {
+void Vec<::com::crypto::game_sdk::RawTxDetail>::set_len(
+    ::std::size_t len) noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$set_len(this, len);
 }
 template <>
 void Vec<::com::crypto::game_sdk::RawTxDetail>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$truncate(this, len);
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTxDetail$truncate(this,
+                                                                      len);
 }
-template <>
-Vec<::com::crypto::game_sdk::RawTokenResult>::Vec() noexcept {
+template <> Vec<::com::crypto::game_sdk::RawTokenResult>::Vec() noexcept {
   cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$new(this);
 }
-template <>
-void Vec<::com::crypto::game_sdk::RawTokenResult>::drop() noexcept {
+template <> void Vec<::com::crypto::game_sdk::RawTokenResult>::drop() noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$drop(this);
 }
 template <>
-::std::size_t Vec<::com::crypto::game_sdk::RawTokenResult>::size() const noexcept {
+::std::size_t
+Vec<::com::crypto::game_sdk::RawTokenResult>::size() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$len(this);
 }
 template <>
-::std::size_t Vec<::com::crypto::game_sdk::RawTokenResult>::capacity() const noexcept {
+::std::size_t
+Vec<::com::crypto::game_sdk::RawTokenResult>::capacity() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$capacity(this);
 }
 template <>
-const ::com::crypto::game_sdk::RawTokenResult *Vec<::com::crypto::game_sdk::RawTokenResult>::data() const noexcept {
+const ::com::crypto::game_sdk::RawTokenResult *
+Vec<::com::crypto::game_sdk::RawTokenResult>::data() const noexcept {
   return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$data(this);
 }
 template <>
-void Vec<::com::crypto::game_sdk::RawTokenResult>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$reserve_total(this, new_cap);
+void Vec<::com::crypto::game_sdk::RawTokenResult>::reserve_total(
+    ::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$reserve_total(
+      this, new_cap);
 }
 template <>
-void Vec<::com::crypto::game_sdk::RawTokenResult>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$set_len(this, len);
+void Vec<::com::crypto::game_sdk::RawTokenResult>::set_len(
+    ::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$set_len(this,
+                                                                        len);
 }
 template <>
 void Vec<::com::crypto::game_sdk::RawTokenResult>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$truncate(this, len);
+  return cxxbridge1$rust_vec$com$crypto$game_sdk$RawTokenResult$truncate(this,
+                                                                         len);
 }
 } // namespace cxxbridge1
 } // namespace rust

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/extra-cpp-bindings/src/lib.rs.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/extra-cpp-bindings/src/lib.rs.h
@@ -22,21 +22,17 @@ inline namespace cxxbridge1 {
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of();
+template <typename T>::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
@@ -155,11 +151,9 @@ private:
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -209,8 +203,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -246,13 +239,11 @@ private:
   std::size_t stride;
 };
 
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -261,49 +252,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -436,16 +419,14 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -466,8 +447,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -488,11 +468,9 @@ private:
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -506,36 +484,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -544,25 +517,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -574,28 +539,24 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
@@ -607,8 +568,7 @@ struct unsafe_bitcopy_t final {
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -640,8 +600,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -669,38 +628,30 @@ private:
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -708,13 +659,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -725,65 +674,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -798,18 +737,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -833,8 +767,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -868,10 +801,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -910,43 +841,38 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
 } // namespace rust
 
 namespace com {
-  namespace crypto {
-    namespace game_sdk {
-      using WalletConnectCallback = ::com::crypto::game_sdk::WalletConnectCallback;
-      using WalletConnectSessionInfo = ::com::crypto::game_sdk::WalletConnectSessionInfo;
-      struct WalletConnectTxLegacy;
-      struct WalletConnectAddress;
-      struct WalletConnectEnsureSessionResult;
-      struct CryptoComPaymentResponse;
-      struct RawTxDetail;
-      struct RawTokenResult;
-      enum class QueryOption : ::std::uint8_t;
-      struct WalletconnectClient;
-      using OptionalArguments = ::com::crypto::game_sdk::OptionalArguments;
-    }
-  }
-}
+namespace crypto {
+namespace game_sdk {
+using WalletConnectCallback = ::com::crypto::game_sdk::WalletConnectCallback;
+using WalletConnectSessionInfo =
+    ::com::crypto::game_sdk::WalletConnectSessionInfo;
+struct WalletConnectTxLegacy;
+struct WalletConnectAddress;
+struct WalletConnectEnsureSessionResult;
+struct CryptoComPaymentResponse;
+struct RawTxDetail;
+struct RawTokenResult;
+enum class QueryOption : ::std::uint8_t;
+struct WalletconnectClient;
+using OptionalArguments = ::com::crypto::game_sdk::OptionalArguments;
+} // namespace game_sdk
+} // namespace crypto
+} // namespace com
 
 namespace com {
 namespace crypto {
 namespace game_sdk {
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectTxLegacy
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectTxLegacy
-  /// wallet connect cronos(eth) legacy-tx signing info
+/// wallet connect cronos(eth) legacy-tx signing info
 struct WalletConnectTxLegacy final {
   ::rust::String to;
   ::rust::String gas;
@@ -961,7 +887,7 @@ struct WalletConnectTxLegacy final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectAddress
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectAddress
-  /// cronos address info
+/// cronos address info
 struct WalletConnectAddress final {
   ::std::array<::std::uint8_t, 20> address;
 
@@ -971,7 +897,7 @@ struct WalletConnectAddress final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectEnsureSessionResult
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletConnectEnsureSessionResult
-  /// walletconnect ensure-session result
+/// walletconnect ensure-session result
 struct WalletConnectEnsureSessionResult final {
   ::rust::Vec<::com::crypto::game_sdk::WalletConnectAddress> addresses;
   ::std::uint64_t chain_id;
@@ -982,7 +908,7 @@ struct WalletConnectEnsureSessionResult final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$CryptoComPaymentResponse
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$CryptoComPaymentResponse
-  /// the subset of payment object from https://pay-docs.crypto.com
+/// the subset of payment object from https://pay-docs.crypto.com
 struct CryptoComPaymentResponse final {
   /// uuid of the payment object
   ::rust::String id;
@@ -1009,7 +935,8 @@ struct CryptoComPaymentResponse final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTxDetail
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTxDetail
-  /// Raw transaction details (extracted from Cronoscan/Etherscan or BlockScout API)
+/// Raw transaction details (extracted from Cronoscan/Etherscan or BlockScout
+/// API)
 struct RawTxDetail final {
   /// Transaction hash
   ::rust::String hash;
@@ -1034,7 +961,7 @@ struct RawTxDetail final {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTokenResult
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$RawTokenResult
-  /// Token ownership result detail from BlockScout API
+/// Token ownership result detail from BlockScout API
 struct RawTokenResult final {
   /// how many tokens are owned by the address
   ::rust::String balance;
@@ -1068,14 +995,17 @@ enum class QueryOption : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
 #define CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
-  /// WallnetConnect API
+/// WallnetConnect API
 struct WalletconnectClient final : public ::rust::Opaque {
   /// setup callback
-  void setup_callback(::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback> usercallback);
+  void setup_callback(
+      ::std::unique_ptr<::com::crypto::game_sdk::WalletConnectCallback>
+          usercallback);
 
   /// create or restore a session
   /// once session is created, it will be reused
-  ::com::crypto::game_sdk::WalletConnectEnsureSessionResult ensure_session_blocking();
+  ::com::crypto::game_sdk::WalletConnectEnsureSessionResult
+  ensure_session_blocking();
 
   /// get connection string for qrcode
   ::rust::String get_connection_string();
@@ -1087,10 +1017,14 @@ struct WalletconnectClient final : public ::rust::Opaque {
   ::rust::String print_uri();
 
   /// sign message
-  ::rust::Vec<::std::uint8_t> sign_personal_blocking(::rust::String message, ::std::array<::std::uint8_t, 20> address);
+  ::rust::Vec<::std::uint8_t>
+  sign_personal_blocking(::rust::String message,
+                         ::std::array<::std::uint8_t, 20> address);
 
   /// sign cronos(eth) legacy-tx
-  ::rust::Vec<::std::uint8_t> sign_legacy_transaction_blocking(const ::com::crypto::game_sdk::WalletConnectTxLegacy &info, ::std::array<::std::uint8_t, 20> address);
+  ::rust::Vec<::std::uint8_t> sign_legacy_transaction_blocking(
+      const ::com::crypto::game_sdk::WalletConnectTxLegacy &info,
+      ::std::array<::std::uint8_t, 20> address);
 
   ~WalletconnectClient() = delete;
 
@@ -1103,28 +1037,52 @@ private:
 };
 #endif // CXXBRIDGE1_STRUCT_com$crypto$game_sdk$WalletconnectClient
 
-  /// restore walletconnect-session from string
-::rust::Box<::com::crypto::game_sdk::WalletconnectClient> walletconnect_restore_client(::rust::String session_info);
+/// restore walletconnect-session from string
+::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+walletconnect_restore_client(::rust::String session_info);
 
-  /// create walletconnect-session
-::rust::Box<::com::crypto::game_sdk::WalletconnectClient> walletconnect_new_client(::rust::String description, ::rust::String url, ::rust::Vec<::rust::String> icon_urls, ::rust::String name);
+/// create walletconnect-session
+::rust::Box<::com::crypto::game_sdk::WalletconnectClient>
+walletconnect_new_client(::rust::String description, ::rust::String url,
+                         ::rust::Vec<::rust::String> icon_urls,
+                         ::rust::String name);
 
-  /// Etherscan API
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_transaction_history_blocking(::rust::String address, ::rust::String api_key);
+/// Etherscan API
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_transaction_history_blocking(::rust::String address,
+                                 ::rust::String api_key);
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_erc20_transfer_history_blocking(::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_erc20_transfer_history_blocking(::rust::String address,
+                                    ::rust::String contract_address,
+                                    ::com::crypto::game_sdk::QueryOption option,
+                                    ::rust::String api_key);
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_erc721_transfer_history_blocking(::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_erc721_transfer_history_blocking(
+    ::rust::String address, ::rust::String contract_address,
+    ::com::crypto::game_sdk::QueryOption option, ::rust::String api_key);
 
-  /// BlockScout API
-::rust::Vec<::com::crypto::game_sdk::RawTokenResult> get_tokens_blocking(::rust::String blockscout_base_url, ::rust::String account_address);
+/// BlockScout API
+::rust::Vec<::com::crypto::game_sdk::RawTokenResult>
+get_tokens_blocking(::rust::String blockscout_base_url,
+                    ::rust::String account_address);
 
-::rust::Vec<::com::crypto::game_sdk::RawTxDetail> get_token_transfers_blocking(::rust::String blockscout_base_url, ::rust::String address, ::rust::String contract_address, ::com::crypto::game_sdk::QueryOption option);
+::rust::Vec<::com::crypto::game_sdk::RawTxDetail>
+get_token_transfers_blocking(::rust::String blockscout_base_url,
+                             ::rust::String address,
+                             ::rust::String contract_address,
+                             ::com::crypto::game_sdk::QueryOption option);
 
-  /// Crypto.com Pay API
-::com::crypto::game_sdk::CryptoComPaymentResponse create_payment(::rust::String secret_or_publishable_api_key, ::rust::String base_unit_amount, ::rust::String currency, const ::com::crypto::game_sdk::OptionalArguments &optional_args);
+/// Crypto.com Pay API
+::com::crypto::game_sdk::CryptoComPaymentResponse
+create_payment(::rust::String secret_or_publishable_api_key,
+               ::rust::String base_unit_amount, ::rust::String currency,
+               const ::com::crypto::game_sdk::OptionalArguments &optional_args);
 
-::com::crypto::game_sdk::CryptoComPaymentResponse get_payment(::rust::String secret_or_publishable_api_key, ::rust::String payment_id);
+::com::crypto::game_sdk::CryptoComPaymentResponse
+get_payment(::rust::String secret_or_publishable_api_key,
+            ::rust::String payment_id);
 } // namespace game_sdk
 } // namespace crypto
 } // namespace com

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/nft.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/nft.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "nft.h"
 

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/pay.cc
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/pay.cc
@@ -1,5 +1,5 @@
-#pragma warning(disable:4583)
-#pragma warning(disable:4582)
+#pragma warning(disable : 4583)
+#pragma warning(disable : 4582)
 
 #include "pay.h"
 #include "extra-cpp-bindings/src/lib.rs.h"
@@ -18,10 +18,11 @@ rust::Str OptionalArguments::get_metadata() const { return metadata; }
 rust::Str OptionalArguments::get_order_id() const { return order_id; }
 rust::Str OptionalArguments::get_return_url() const { return return_url; }
 rust::Str OptionalArguments::get_cancel_url() const { return cancel_url; }
-rust::Str OptionalArguments::get_sub_merchant_id() const { return sub_merchant_id; }
+rust::Str OptionalArguments::get_sub_merchant_id() const {
+  return sub_merchant_id;
+}
 bool OptionalArguments::get_onchain_allowed() const { return onchain_allowed; }
 uint64_t OptionalArguments::get_expired_at() const { return expired_at; }
-
 
 } // namespace game_sdk
 } // namespace crypto

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/pay.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/pay.h
@@ -11,24 +11,27 @@ namespace game_sdk {
 struct OptionalArguments {
   /// An arbitrary string attached to the object.
   rust::String description;
-  /// Set of key-value pairs that you can attach to an object. This can be useful for storing
-  /// additional information about the object in a structured format.
+  /// Set of key-value pairs that you can attach to an object. This can be
+  /// useful for storing additional information about the object in a structured
+  /// format.
   rust::String metadata;
   /// Merchant provided order ID for this payment.
   rust::String order_id;
-  /// The URL for payment page to redirect back to when the payment becomes succeeded. It is
-  /// required for redirection flow.
+  /// The URL for payment page to redirect back to when the payment becomes
+  /// succeeded. It is required for redirection flow.
   rust::String return_url;
-  /// The URL for payment page to redirect to when the payment is failed or cancelled.
+  /// The URL for payment page to redirect to when the payment is failed or
+  /// cancelled.
   rust::String cancel_url;
-  /// ID of the sub-merchant associated with this payment. It is required for merchant
-  /// acquirers.
+  /// ID of the sub-merchant associated with this payment. It is required for
+  /// merchant acquirers.
   rust::String sub_merchant_id;
-  /// Whether to allow the customer to pay by Other Cryptocurrency Wallets for this payment. If
-  /// not specified, the setting in merchant account will be used.
+  /// Whether to allow the customer to pay by Other Cryptocurrency Wallets for
+  /// this payment. If not specified, the setting in merchant account will be
+  /// used.
   bool onchain_allowed;
-  /// Time at which the payment expires. Measured in seconds since the Unix epoch. If 0, it
-  /// will expire after the default period(10 minutes).
+  /// Time at which the payment expires. Measured in seconds since the Unix
+  /// epoch. If 0, it will expire after the default period(10 minutes).
   uint64_t expired_at;
 
   OptionalArguments();

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/rust/cxx.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Private/cronosplay/include/rust/cxx.h
@@ -26,8 +26,7 @@ inline namespace cxxbridge1 {
 struct unsafe_bitcopy_t;
 
 namespace {
-template <typename T>
-class impl;
+template <typename T> class impl;
 }
 
 #ifndef CXXBRIDGE1_RUST_STRING
@@ -154,11 +153,9 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 namespace detail {
-template <bool>
-struct copy_assignable_if {};
+template <bool> struct copy_assignable_if {};
 
-template <>
-struct copy_assignable_if<false> {
+template <> struct copy_assignable_if<false> {
   copy_assignable_if() noexcept = default;
   copy_assignable_if(const copy_assignable_if &) noexcept = default;
   copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
@@ -210,8 +207,7 @@ private:
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
@@ -250,8 +246,7 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_BOX
 // https://cxx.rs/binding/box.html
-template <typename T>
-class Box final {
+template <typename T> class Box final {
 public:
   using element_type = T;
   using const_pointer =
@@ -272,8 +267,7 @@ public:
   T *operator->() noexcept;
   T &operator*() noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place(Fields &&...);
 
   void swap(Box &) noexcept;
 
@@ -299,8 +293,7 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_VEC
 // https://cxx.rs/binding/vec.html
-template <typename T>
-class Vec final {
+template <typename T> class Vec final {
 public:
   using value_type = T;
 
@@ -332,8 +325,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
+  template <typename... Args> void emplace_back(Args &&...args);
   void truncate(std::size_t len);
   void clear();
 
@@ -366,11 +358,9 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_FN
 // https://cxx.rs/binding/fn.html
-template <typename Signature>
-class Fn;
+template <typename Signature> class Fn;
 
-template <typename Ret, typename... Args>
-class Fn<Ret(Args...)> final {
+template <typename Ret, typename... Args> class Fn<Ret(Args...)> final {
 public:
   Ret operator()(Args... args) const noexcept;
   Fn operator*() const noexcept;
@@ -426,10 +416,8 @@ public:
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
-template <typename T>
-std::size_t size_of();
-template <typename T>
-std::size_t align_of();
+template <typename T> std::size_t size_of();
+template <typename T> std::size_t align_of();
 
 // IsRelocatable<T> is used in assertions that a C++ type passed by value
 // between Rust and C++ is soundly relocatable by Rust.
@@ -449,8 +437,7 @@ std::size_t align_of();
 //      --- otherwise:
 //    + template <>
 //    + struct rust::IsRelocatable<MyType> : std::true_type {};
-template <typename T>
-struct IsRelocatable;
+template <typename T> struct IsRelocatable;
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
@@ -467,27 +454,19 @@ using f64 = double;
 // Snake case aliases for use in code that uses this style for type names.
 using string = String;
 using str = Str;
-template <typename T>
-using slice = Slice<T>;
-template <typename T>
-using box = Box<T>;
-template <typename T>
-using vec = Vec<T>;
+template <typename T> using slice = Slice<T>;
+template <typename T> using box = Box<T>;
+template <typename T> using vec = Vec<T>;
 using error = Error;
-template <typename Signature>
-using fn = Fn<Signature>;
-template <typename T>
-using is_relocatable = IsRelocatable<T>;
-
-
+template <typename Signature> using fn = Fn<Signature>;
+template <typename T> using is_relocatable = IsRelocatable<T>;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// end public API, begin implementation details
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 #ifndef CXXBRIDGE1_RUST_FN
@@ -517,13 +496,11 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-template <typename T>
-Slice<T>::Slice() noexcept {
+template <typename T> Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
-template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
+template <typename T> Slice<T>::Slice(T *s, std::size_t count) noexcept {
   assert(s != nullptr || count == 0);
   sliceInit(this,
             s == nullptr && count == 0
@@ -532,49 +509,41 @@ Slice<T>::Slice(T *s, std::size_t count) noexcept {
             count);
 }
 
-template <typename T>
-T *Slice<T>::data() const noexcept {
+template <typename T> T *Slice<T>::data() const noexcept {
   return reinterpret_cast<T *>(slicePtr(this));
 }
 
-template <typename T>
-std::size_t Slice<T>::size() const noexcept {
+template <typename T> std::size_t Slice<T>::size() const noexcept {
   return sliceLen(this);
 }
 
-template <typename T>
-std::size_t Slice<T>::length() const noexcept {
+template <typename T> std::size_t Slice<T>::length() const noexcept {
   return this->size();
 }
 
-template <typename T>
-bool Slice<T>::empty() const noexcept {
+template <typename T> bool Slice<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
+template <typename T> T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
   return *reinterpret_cast<T *>(ptr);
 }
 
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
+template <typename T> T &Slice<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Slice index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Slice<T>::front() const noexcept {
+template <typename T> T &Slice<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Slice<T>::back() const noexcept {
+template <typename T> T &Slice<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
@@ -707,19 +676,16 @@ typename Slice<T>::iterator Slice<T>::end() const noexcept {
   return it;
 }
 
-template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
+template <typename T> void Slice<T>::swap(Slice &rhs) noexcept {
   std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit {};
 
-template <typename T>
-class Box<T>::allocation {
+template <typename T> class Box<T>::allocation {
   static T *alloc() noexcept;
   static void dealloc(T *) noexcept;
 
@@ -733,36 +699,31 @@ public:
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+template <typename T> Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
   other.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box(const T &val) {
   allocation alloc;
   ::new (alloc.ptr) T(val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box(T &&val) {
   allocation alloc;
   ::new (alloc.ptr) T(std::move(val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
+template <typename T> Box<T>::~Box() noexcept {
   if (this->ptr) {
     this->drop();
   }
 }
 
-template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+template <typename T> Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   if (this->ptr) {
     this->drop();
   }
@@ -771,25 +732,17 @@ Box<T> &Box<T>::operator=(Box &&other) &noexcept {
   return *this;
 }
 
-template <typename T>
-const T *Box<T>::operator->() const noexcept {
+template <typename T> const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
-template <typename T>
-const T &Box<T>::operator*() const noexcept {
+template <typename T> const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
-template <typename T>
-T *Box<T>::operator->() noexcept {
-  return this->ptr;
-}
+template <typename T> T *Box<T>::operator->() noexcept { return this->ptr; }
 
-template <typename T>
-T &Box<T>::operator*() noexcept {
-  return *this->ptr;
-}
+template <typename T> T &Box<T>::operator*() noexcept { return *this->ptr; }
 
 template <typename T>
 template <typename... Fields>
@@ -801,64 +754,52 @@ Box<T> Box<T>::in_place(Fields &&...fields) {
   return from_raw(ptr);
 }
 
-template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+template <typename T> void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
   swap(this->ptr, rhs.ptr);
 }
 
-template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+template <typename T> Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
-template <typename T>
-T *Box<T>::into_raw() noexcept {
+template <typename T> T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+template <typename T> Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
   this->reserve_total(init.size());
   std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
+template <typename T> Vec<T>::Vec(const Vec &other) : Vec() {
   this->reserve_total(other.size());
   std::copy(other.begin(), other.end(), std::back_inserter(*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+template <typename T> Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
   new (&other) Vec();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec() noexcept { this->drop(); }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+template <typename T> Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
   this->drop();
   this->repr = other.repr;
   new (&other) Vec();
   return *this;
 }
 
-template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
+template <typename T> Vec<T> &Vec<T>::operator=(const Vec &other) & {
   if (this != &other) {
     this->drop();
     new (this) Vec(other);
@@ -866,13 +807,11 @@ Vec<T> &Vec<T>::operator=(const Vec &other) & {
   return *this;
 }
 
-template <typename T>
-bool Vec<T>::empty() const noexcept {
+template <typename T> bool Vec<T>::empty() const noexcept {
   return this->size() == 0;
 }
 
-template <typename T>
-T *Vec<T>::data() noexcept {
+template <typename T> T *Vec<T>::data() noexcept {
   return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
@@ -883,65 +822,55 @@ const T &Vec<T>::operator[](std::size_t n) const noexcept {
   return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
+template <typename T> const T &Vec<T>::at(std::size_t n) const {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-const T &Vec<T>::front() const noexcept {
+template <typename T> const T &Vec<T>::front() const noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-const T &Vec<T>::back() const noexcept {
+template <typename T> const T &Vec<T>::back() const noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
+template <typename T> T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
   return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
-template <typename T>
-T &Vec<T>::at(std::size_t n) {
+template <typename T> T &Vec<T>::at(std::size_t n) {
   if (n >= this->size()) {
     panic<std::out_of_range>("rust::Vec index out of range");
   }
   return (*this)[n];
 }
 
-template <typename T>
-T &Vec<T>::front() noexcept {
+template <typename T> T &Vec<T>::front() noexcept {
   assert(!this->empty());
   return (*this)[0];
 }
 
-template <typename T>
-T &Vec<T>::back() noexcept {
+template <typename T> T &Vec<T>::back() noexcept {
   assert(!this->empty());
   return (*this)[this->size() - 1];
 }
 
-template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
+template <typename T> void Vec<T>::reserve(std::size_t new_cap) {
   this->reserve_total(new_cap);
 }
 
-template <typename T>
-void Vec<T>::push_back(const T &value) {
+template <typename T> void Vec<T>::push_back(const T &value) {
   this->emplace_back(value);
 }
 
-template <typename T>
-void Vec<T>::push_back(T &&value) {
+template <typename T> void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
 }
 
@@ -956,18 +885,13 @@ void Vec<T>::emplace_back(Args &&...args) {
   this->set_len(size + 1);
 }
 
-template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
-}
+template <typename T> void Vec<T>::clear() { this->truncate(0); }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::begin() noexcept {
   return Slice<T>(this->data(), this->size()).begin();
 }
 
-template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
+template <typename T> typename Vec<T>::iterator Vec<T>::end() noexcept {
   return Slice<T>(this->data(), this->size()).end();
 }
 
@@ -991,8 +915,7 @@ typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
   return Slice<const T>(this->data(), this->size()).end();
 }
 
-template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+template <typename T> void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
   swap(this->repr, rhs.repr);
 }
@@ -1017,10 +940,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
 class layout {
-  template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
+  template <typename T> friend std::size_t size_of();
+  template <typename T> friend std::size_t align_of();
   template <typename T>
   static typename std::enable_if<std::is_base_of<Opaque, T>::value,
                                  std::size_t>::type
@@ -1059,27 +980,17 @@ class layout {
   }
 };
 
-template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
-}
+template <typename T> std::size_t size_of() { return layout::size_of<T>(); }
 
-template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
-}
+template <typename T> std::size_t align_of() { return layout::align_of<T>(); }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
 namespace detail {
-template <typename... Ts>
-struct make_void {
-  using type = void;
-};
+template <typename... Ts> struct make_void { using type = void; };
 
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 template <typename Void, template <typename...> class, typename...>
 struct detect : std::false_type {};
@@ -1089,8 +1000,7 @@ struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
 template <template <typename...> class T, typename... A>
 using is_detected = detect<void, T, A...>;
 
-template <typename T>
-using detect_IsRelocatable = typename T::IsRelocatable;
+template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
 
 template <typename T>
 struct get_IsRelocatable

--- a/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Public/DefiWalletCoreActor.h
+++ b/CronosPlaySdk/Plugins/CronosPlayUnreal/Source/CronosPlayUnreal/Public/DefiWalletCoreActor.h
@@ -13,7 +13,7 @@
 #include "DefiWalletCoreActor.generated.h"
 
 /*
-TODO: 
+TODO:
 for erc20,erc721,erc1155
 add opaque pointer for each api, and don't recreate in very call
 add like apis

--- a/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdk.cpp
+++ b/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdk.cpp
@@ -2,5 +2,5 @@
 #include "CronosPlaySdk.h"
 #include "Modules/ModuleManager.h"
 
-IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, CronosPlaySdk, "CronosPlaySdk" );
- 
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, CronosPlaySdk,
+                              "CronosPlaySdk");

--- a/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkCharacter.cpp
+++ b/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkCharacter.cpp
@@ -11,129 +11,147 @@
 //////////////////////////////////////////////////////////////////////////
 // ACronosPlaySdkCharacter
 
-ACronosPlaySdkCharacter::ACronosPlaySdkCharacter()
-{
-	// Set size for collision capsule
-	GetCapsuleComponent()->InitCapsuleSize(42.f, 96.0f);
+ACronosPlaySdkCharacter::ACronosPlaySdkCharacter() {
+  // Set size for collision capsule
+  GetCapsuleComponent()->InitCapsuleSize(42.f, 96.0f);
 
-	// set our turn rates for input
-	BaseTurnRate = 45.f;
-	BaseLookUpRate = 45.f;
+  // set our turn rates for input
+  BaseTurnRate = 45.f;
+  BaseLookUpRate = 45.f;
 
-	// Don't rotate when the controller rotates. Let that just affect the camera.
-	bUseControllerRotationPitch = false;
-	bUseControllerRotationYaw = false;
-	bUseControllerRotationRoll = false;
+  // Don't rotate when the controller rotates. Let that just affect the camera.
+  bUseControllerRotationPitch = false;
+  bUseControllerRotationYaw = false;
+  bUseControllerRotationRoll = false;
 
-	// Configure character movement
-	GetCharacterMovement()->bOrientRotationToMovement = true; // Character moves in the direction of input...	
-	GetCharacterMovement()->RotationRate = FRotator(0.0f, 540.0f, 0.0f); // ...at this rotation rate
-	GetCharacterMovement()->JumpZVelocity = 600.f;
-	GetCharacterMovement()->AirControl = 0.2f;
+  // Configure character movement
+  GetCharacterMovement()->bOrientRotationToMovement =
+      true; // Character moves in the direction of input...
+  GetCharacterMovement()->RotationRate =
+      FRotator(0.0f, 540.0f, 0.0f); // ...at this rotation rate
+  GetCharacterMovement()->JumpZVelocity = 600.f;
+  GetCharacterMovement()->AirControl = 0.2f;
 
-	// Create a camera boom (pulls in towards the player if there is a collision)
-	CameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
-	CameraBoom->SetupAttachment(RootComponent);
-	CameraBoom->TargetArmLength = 300.0f; // The camera follows at this distance behind the character	
-	CameraBoom->bUsePawnControlRotation = true; // Rotate the arm based on the controller
+  // Create a camera boom (pulls in towards the player if there is a collision)
+  CameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
+  CameraBoom->SetupAttachment(RootComponent);
+  CameraBoom->TargetArmLength =
+      300.0f; // The camera follows at this distance behind the character
+  CameraBoom->bUsePawnControlRotation =
+      true; // Rotate the arm based on the controller
 
-	// Create a follow camera
-	FollowCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("FollowCamera"));
-	FollowCamera->SetupAttachment(CameraBoom, USpringArmComponent::SocketName); // Attach the camera to the end of the boom and let the boom adjust to match the controller orientation
-	FollowCamera->bUsePawnControlRotation = false; // Camera does not rotate relative to arm
+  // Create a follow camera
+  FollowCamera = CreateDefaultSubobject<UCameraComponent>(TEXT("FollowCamera"));
+  FollowCamera->SetupAttachment(
+      CameraBoom,
+      USpringArmComponent::SocketName); // Attach the camera to the end of the
+                                        // boom and let the boom adjust to match
+                                        // the controller orientation
+  FollowCamera->bUsePawnControlRotation =
+      false; // Camera does not rotate relative to arm
 
-	// Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character) 
-	// are set in the derived blueprint asset named MyCharacter (to avoid direct content references in C++)
+  // Note: The skeletal mesh and anim blueprint references on the Mesh component
+  // (inherited from Character) are set in the derived blueprint asset named
+  // MyCharacter (to avoid direct content references in C++)
 }
 
 //////////////////////////////////////////////////////////////////////////
 // Input
 
-void ACronosPlaySdkCharacter::SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent)
-{
-	// Set up gameplay key bindings
-	check(PlayerInputComponent);
-	PlayerInputComponent->BindAction("Jump", IE_Pressed, this, &ACharacter::Jump);
-	PlayerInputComponent->BindAction("Jump", IE_Released, this, &ACharacter::StopJumping);
+void ACronosPlaySdkCharacter::SetupPlayerInputComponent(
+    class UInputComponent *PlayerInputComponent) {
+  // Set up gameplay key bindings
+  check(PlayerInputComponent);
+  PlayerInputComponent->BindAction("Jump", IE_Pressed, this, &ACharacter::Jump);
+  PlayerInputComponent->BindAction("Jump", IE_Released, this,
+                                   &ACharacter::StopJumping);
 
-	PlayerInputComponent->BindAxis("MoveForward", this, &ACronosPlaySdkCharacter::MoveForward);
-	PlayerInputComponent->BindAxis("MoveRight", this, &ACronosPlaySdkCharacter::MoveRight);
+  PlayerInputComponent->BindAxis("MoveForward", this,
+                                 &ACronosPlaySdkCharacter::MoveForward);
+  PlayerInputComponent->BindAxis("MoveRight", this,
+                                 &ACronosPlaySdkCharacter::MoveRight);
 
-	// We have 2 versions of the rotation bindings to handle different kinds of devices differently
-	// "turn" handles devices that provide an absolute delta, such as a mouse.
-	// "turnrate" is for devices that we choose to treat as a rate of change, such as an analog joystick
-	PlayerInputComponent->BindAxis("Turn", this, &APawn::AddControllerYawInput);
-	PlayerInputComponent->BindAxis("TurnRate", this, &ACronosPlaySdkCharacter::TurnAtRate);
-	PlayerInputComponent->BindAxis("LookUp", this, &APawn::AddControllerPitchInput);
-	PlayerInputComponent->BindAxis("LookUpRate", this, &ACronosPlaySdkCharacter::LookUpAtRate);
+  // We have 2 versions of the rotation bindings to handle different kinds of
+  // devices differently "turn" handles devices that provide an absolute delta,
+  // such as a mouse. "turnrate" is for devices that we choose to treat as a
+  // rate of change, such as an analog joystick
+  PlayerInputComponent->BindAxis("Turn", this, &APawn::AddControllerYawInput);
+  PlayerInputComponent->BindAxis("TurnRate", this,
+                                 &ACronosPlaySdkCharacter::TurnAtRate);
+  PlayerInputComponent->BindAxis("LookUp", this,
+                                 &APawn::AddControllerPitchInput);
+  PlayerInputComponent->BindAxis("LookUpRate", this,
+                                 &ACronosPlaySdkCharacter::LookUpAtRate);
 
-	// handle touch devices
-	PlayerInputComponent->BindTouch(IE_Pressed, this, &ACronosPlaySdkCharacter::TouchStarted);
-	PlayerInputComponent->BindTouch(IE_Released, this, &ACronosPlaySdkCharacter::TouchStopped);
+  // handle touch devices
+  PlayerInputComponent->BindTouch(IE_Pressed, this,
+                                  &ACronosPlaySdkCharacter::TouchStarted);
+  PlayerInputComponent->BindTouch(IE_Released, this,
+                                  &ACronosPlaySdkCharacter::TouchStopped);
 
-	// VR headset functionality
-	PlayerInputComponent->BindAction("ResetVR", IE_Pressed, this, &ACronosPlaySdkCharacter::OnResetVR);
+  // VR headset functionality
+  PlayerInputComponent->BindAction("ResetVR", IE_Pressed, this,
+                                   &ACronosPlaySdkCharacter::OnResetVR);
 }
 
-
-void ACronosPlaySdkCharacter::OnResetVR()
-{
-	// If CronosPlaySdk is added to a project via 'Add Feature' in the Unreal Editor the dependency on HeadMountedDisplay in CronosPlaySdk.Build.cs is not automatically propagated
-	// and a linker error will result.
-	// You will need to either:
-	//		Add "HeadMountedDisplay" to [YourProject].Build.cs PublicDependencyModuleNames in order to build successfully (appropriate if supporting VR).
-	// or:
-	//		Comment or delete the call to ResetOrientationAndPosition below (appropriate if not supporting VR)
-	UHeadMountedDisplayFunctionLibrary::ResetOrientationAndPosition();
+void ACronosPlaySdkCharacter::OnResetVR() {
+  // If CronosPlaySdk is added to a project via 'Add Feature' in the Unreal
+  // Editor the dependency on HeadMountedDisplay in CronosPlaySdk.Build.cs is
+  // not automatically propagated and a linker error will result. You will need
+  // to either:
+  //		Add "HeadMountedDisplay" to [YourProject].Build.cs
+  // PublicDependencyModuleNames in order to build successfully (appropriate if
+  // supporting VR).
+  // or:
+  //		Comment or delete the call to ResetOrientationAndPosition below
+  //(appropriate if not supporting VR)
+  UHeadMountedDisplayFunctionLibrary::ResetOrientationAndPosition();
 }
 
-void ACronosPlaySdkCharacter::TouchStarted(ETouchIndex::Type FingerIndex, FVector Location)
-{
-		Jump();
+void ACronosPlaySdkCharacter::TouchStarted(ETouchIndex::Type FingerIndex,
+                                           FVector Location) {
+  Jump();
 }
 
-void ACronosPlaySdkCharacter::TouchStopped(ETouchIndex::Type FingerIndex, FVector Location)
-{
-		StopJumping();
+void ACronosPlaySdkCharacter::TouchStopped(ETouchIndex::Type FingerIndex,
+                                           FVector Location) {
+  StopJumping();
 }
 
-void ACronosPlaySdkCharacter::TurnAtRate(float Rate)
-{
-	// calculate delta for this frame from the rate information
-	AddControllerYawInput(Rate * BaseTurnRate * GetWorld()->GetDeltaSeconds());
+void ACronosPlaySdkCharacter::TurnAtRate(float Rate) {
+  // calculate delta for this frame from the rate information
+  AddControllerYawInput(Rate * BaseTurnRate * GetWorld()->GetDeltaSeconds());
 }
 
-void ACronosPlaySdkCharacter::LookUpAtRate(float Rate)
-{
-	// calculate delta for this frame from the rate information
-	AddControllerPitchInput(Rate * BaseLookUpRate * GetWorld()->GetDeltaSeconds());
+void ACronosPlaySdkCharacter::LookUpAtRate(float Rate) {
+  // calculate delta for this frame from the rate information
+  AddControllerPitchInput(Rate * BaseLookUpRate *
+                          GetWorld()->GetDeltaSeconds());
 }
 
-void ACronosPlaySdkCharacter::MoveForward(float Value)
-{
-	if ((Controller != nullptr) && (Value != 0.0f))
-	{
-		// find out which way is forward
-		const FRotator Rotation = Controller->GetControlRotation();
-		const FRotator YawRotation(0, Rotation.Yaw, 0);
+void ACronosPlaySdkCharacter::MoveForward(float Value) {
+  if ((Controller != nullptr) && (Value != 0.0f)) {
+    // find out which way is forward
+    const FRotator Rotation = Controller->GetControlRotation();
+    const FRotator YawRotation(0, Rotation.Yaw, 0);
 
-		// get forward vector
-		const FVector Direction = FRotationMatrix(YawRotation).GetUnitAxis(EAxis::X);
-		AddMovementInput(Direction, Value);
-	}
+    // get forward vector
+    const FVector Direction =
+        FRotationMatrix(YawRotation).GetUnitAxis(EAxis::X);
+    AddMovementInput(Direction, Value);
+  }
 }
 
-void ACronosPlaySdkCharacter::MoveRight(float Value)
-{
-	if ( (Controller != nullptr) && (Value != 0.0f) )
-	{
-		// find out which way is right
-		const FRotator Rotation = Controller->GetControlRotation();
-		const FRotator YawRotation(0, Rotation.Yaw, 0);
-	
-		// get right vector 
-		const FVector Direction = FRotationMatrix(YawRotation).GetUnitAxis(EAxis::Y);
-		// add movement in that direction
-		AddMovementInput(Direction, Value);
-	}
+void ACronosPlaySdkCharacter::MoveRight(float Value) {
+  if ((Controller != nullptr) && (Value != 0.0f)) {
+    // find out which way is right
+    const FRotator Rotation = Controller->GetControlRotation();
+    const FRotator YawRotation(0, Rotation.Yaw, 0);
+
+    // get right vector
+    const FVector Direction =
+        FRotationMatrix(YawRotation).GetUnitAxis(EAxis::Y);
+    // add movement in that direction
+    AddMovementInput(Direction, Value);
+  }
 }

--- a/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkCharacter.h
+++ b/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkCharacter.h
@@ -5,67 +5,75 @@
 #include "GameFramework/Character.h"
 #include "CronosPlaySdkCharacter.generated.h"
 
-UCLASS(config=Game)
-class ACronosPlaySdkCharacter : public ACharacter
-{
-	GENERATED_BODY()
+UCLASS(config = Game)
+class ACronosPlaySdkCharacter : public ACharacter {
+  GENERATED_BODY()
 
-	/** Camera boom positioning the camera behind the character */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
-	class USpringArmComponent* CameraBoom;
+  /** Camera boom positioning the camera behind the character */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera,
+            meta = (AllowPrivateAccess = "true"))
+  class USpringArmComponent *CameraBoom;
 
-	/** Follow camera */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
-	class UCameraComponent* FollowCamera;
-public:
-	ACronosPlaySdkCharacter();
-
-	/** Base turn rate, in deg/sec. Other scaling may affect final turn rate. */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category=Camera)
-	float BaseTurnRate;
-
-	/** Base look up/down rate, in deg/sec. Other scaling may affect final rate. */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category=Camera)
-	float BaseLookUpRate;
-
-protected:
-
-	/** Resets HMD orientation in VR. */
-	void OnResetVR();
-
-	/** Called for forwards/backward input */
-	void MoveForward(float Value);
-
-	/** Called for side to side input */
-	void MoveRight(float Value);
-
-	/** 
-	 * Called via input to turn at a given rate. 
-	 * @param Rate	This is a normalized rate, i.e. 1.0 means 100% of desired turn rate
-	 */
-	void TurnAtRate(float Rate);
-
-	/**
-	 * Called via input to turn look up/down at a given rate. 
-	 * @param Rate	This is a normalized rate, i.e. 1.0 means 100% of desired turn rate
-	 */
-	void LookUpAtRate(float Rate);
-
-	/** Handler for when a touch input begins. */
-	void TouchStarted(ETouchIndex::Type FingerIndex, FVector Location);
-
-	/** Handler for when a touch input stops. */
-	void TouchStopped(ETouchIndex::Type FingerIndex, FVector Location);
-
-protected:
-	// APawn interface
-	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
-	// End of APawn interface
+  /** Follow camera */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera,
+            meta = (AllowPrivateAccess = "true"))
+  class UCameraComponent *FollowCamera;
 
 public:
-	/** Returns CameraBoom subobject **/
-	FORCEINLINE class USpringArmComponent* GetCameraBoom() const { return CameraBoom; }
-	/** Returns FollowCamera subobject **/
-	FORCEINLINE class UCameraComponent* GetFollowCamera() const { return FollowCamera; }
+  ACronosPlaySdkCharacter();
+
+  /** Base turn rate, in deg/sec. Other scaling may affect final turn rate. */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera)
+  float BaseTurnRate;
+
+  /** Base look up/down rate, in deg/sec. Other scaling may affect final rate.
+   */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera)
+  float BaseLookUpRate;
+
+protected:
+  /** Resets HMD orientation in VR. */
+  void OnResetVR();
+
+  /** Called for forwards/backward input */
+  void MoveForward(float Value);
+
+  /** Called for side to side input */
+  void MoveRight(float Value);
+
+  /**
+   * Called via input to turn at a given rate.
+   * @param Rate	This is a normalized rate, i.e. 1.0 means 100% of
+   * desired turn rate
+   */
+  void TurnAtRate(float Rate);
+
+  /**
+   * Called via input to turn look up/down at a given rate.
+   * @param Rate	This is a normalized rate, i.e. 1.0 means 100% of
+   * desired turn rate
+   */
+  void LookUpAtRate(float Rate);
+
+  /** Handler for when a touch input begins. */
+  void TouchStarted(ETouchIndex::Type FingerIndex, FVector Location);
+
+  /** Handler for when a touch input stops. */
+  void TouchStopped(ETouchIndex::Type FingerIndex, FVector Location);
+
+protected:
+  // APawn interface
+  virtual void SetupPlayerInputComponent(
+      class UInputComponent *PlayerInputComponent) override;
+  // End of APawn interface
+
+public:
+  /** Returns CameraBoom subobject **/
+  FORCEINLINE class USpringArmComponent *GetCameraBoom() const {
+    return CameraBoom;
+  }
+  /** Returns FollowCamera subobject **/
+  FORCEINLINE class UCameraComponent *GetFollowCamera() const {
+    return FollowCamera;
+  }
 };
-

--- a/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkGameMode.cpp
+++ b/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkGameMode.cpp
@@ -3,12 +3,11 @@
 #include "CronosPlaySdkCharacter.h"
 #include "UObject/ConstructorHelpers.h"
 
-ACronosPlaySdkGameMode::ACronosPlaySdkGameMode()
-{
-	// set default pawn class to our Blueprinted character
-	static ConstructorHelpers::FClassFinder<APawn> PlayerPawnBPClass(TEXT("/Game/ThirdPersonCPP/Blueprints/ThirdPersonCharacter"));
-	if (PlayerPawnBPClass.Class != NULL)
-	{
-		DefaultPawnClass = PlayerPawnBPClass.Class;
-	}
+ACronosPlaySdkGameMode::ACronosPlaySdkGameMode() {
+  // set default pawn class to our Blueprinted character
+  static ConstructorHelpers::FClassFinder<APawn> PlayerPawnBPClass(
+      TEXT("/Game/ThirdPersonCPP/Blueprints/ThirdPersonCharacter"));
+  if (PlayerPawnBPClass.Class != NULL) {
+    DefaultPawnClass = PlayerPawnBPClass.Class;
+  }
 }

--- a/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkGameMode.h
+++ b/CronosPlaySdk/Source/CronosPlaySdk/CronosPlaySdkGameMode.h
@@ -6,13 +6,9 @@
 #include "CronosPlaySdkGameMode.generated.h"
 
 UCLASS(minimalapi)
-class ACronosPlaySdkGameMode : public AGameModeBase
-{
-	GENERATED_BODY()
+class ACronosPlaySdkGameMode : public AGameModeBase {
+  GENERATED_BODY()
 
 public:
-	ACronosPlaySdkGameMode();
+  ACronosPlaySdkGameMode();
 };
-
-
-

--- a/CronosPlaySdk/reformat.sh
+++ b/CronosPlaySdk/reformat.sh
@@ -1,0 +1,1 @@
+find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" | xargs clang-format -i -style="{SortIncludes: Never}"


### PR DESCRIPTION
Solution: reformat
```
find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" | xargs clang-format -i -style="{SortIncludes: Never}"
```