### PR TITLE
Problem: Missing windows native method to prepare the plugin (fix #99)

### DIFF
--- a/install-play-cpp-sdk.bat
+++ b/install-play-cpp-sdk.bat
@@ -1,0 +1,19 @@
+set PLAYCPPSDK=v0.0.2-alpha
+set WINDOWSSRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/play_cpp_sdk_Windows_x86_64.zip
+set WINDOWSHASH="43624bcb713b901986ce0d526f7f718bfff4a27c29d413130cf4a4469d0cac68 play_cpp_sdk_Windows_x86_64.zip"
+
+rmdir install\windows\ /s /q
+rmdir ThirdParty\cronosplay\lib\Win64\ /s /q
+
+mkdir -p install\windows
+mkdir -p ThirdParty\cronosplay\lib\Win64
+
+cd install\windows
+powershell -Command "Invoke-WebRequest %WINDOWSSRC% -OutFile play_cpp_sdk_Windows_x86_64.zip"
+
+echo %WINDOWSHASH% | sha256sum -c  -
+unzip play_cpp_sdk_Windows_x86_64.zip
+
+Xcopy /E/I sdk\lib ..\..\ThirdParty\cronosplay\lib\Win64
+
+cd ..\..

--- a/install-play-cpp-sdk.bat
+++ b/install-play-cpp-sdk.bat
@@ -1,6 +1,6 @@
-set PLAYCPPSDK=v0.0.2-alpha
+set PLAYCPPSDK=v0.0.3-alpha
 set WINDOWSSRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/play_cpp_sdk_Windows_x86_64.zip
-set WINDOWSHASH="43624bcb713b901986ce0d526f7f718bfff4a27c29d413130cf4a4469d0cac68 play_cpp_sdk_Windows_x86_64.zip"
+set WINDOWSHASH="9ad8bedaaa96e8a5898126d40da527a4180b8c7cfe8ab7a2d6d01445ad476efd play_cpp_sdk_Windows_x86_64.zip"
 
 rmdir install\windows\ /s /q
 rmdir ThirdParty\cronosplay\lib\Win64\ /s /q


### PR DESCRIPTION
Solution:
- Add install-play-cpp-sdk.bat

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles in Unreal Engine 4 and 5?
- [ ] Have you checked your basic code formatting and style is fine? ([using this Linter plugin](https://ue4-style-guide.readthedocs.io/en/latest/gettingstarted.html))
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the plugin version number and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
