### PR TITLE
Problem: Missing windows build command (fix #235)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ UNAME := $(shell uname)
 PWD = $(shell pwd)
 
 # Set the play cpp sdk version
-PLAYCPPSDK=v0.0.13-alpha
+PLAYCPPSDK=v0.0.14-alpha
 # Set NDK versions (to see what NDK_VERSION is available, please check play-cpp-sdk release page)
 NDK_VERSION=21.4.7075529
 # Set names of play cpp sdk library files

--- a/README.md
+++ b/README.md
@@ -27,12 +27,9 @@ Skip this step if you prefer building from source.
 Skip this step if you prefer building from the release zip file.
 
 - Step 2a: Clone this project
-- Step 2b: run `make` (mac) or run `install-play-cpp-sdk.bat` (windows) to setup [play-cpp-sdk](https://github.com/cronos-labs/play-cpp-sdk).
+- Step 2b: run `make` (mac/linux) or run `install-play-cpp-sdk.bat` (windows) to setup [play-cpp-sdk](https://github.com/cronos-labs/play-cpp-sdk).
 
-### Step 3: Run RunUAT.bat[or RunUAT.sh] script to build the plugin
-``` bash
-Engine\Build\BatchFiles\RunUAT.bat[or RunUAT.sh] BuildPlugin -Plugin=[Path to .uplugin file, must be outside engine directory] -Package=[Output directory] -Rocket
-```
+### Step 3: Run `make RunUAT` (mac/linux) or run `windows-build.bat` (windows) to build the Plugin
 
 ### Windows
 Make sure you use Visual Studio 2019 or newer.

--- a/install-play-cpp-sdk.bat
+++ b/install-play-cpp-sdk.bat
@@ -1,5 +1,5 @@
 REM Set the play cpp sdk version
-set PLAYCPPSDK=v0.0.8-alpha
+set PLAYCPPSDK=v0.0.14-alpha
 
 REM Set NDK versions (to see what NDK_VERSION is available, please check play-cpp-sdk release page)
 set NDK_VERSION=21.4.7075529
@@ -11,6 +11,7 @@ set LINUX_FILE=play_cpp_sdk_libc++_Linux_x86_64.tar.gz
 set ARM64_V8A_FILE=play_cpp_sdk_aarch64-linux-android-%NDK_VERSION%.tar.gz
 set ARMEABI_V7A_FILE=play_cpp_sdk_armv7-linux-androideabi-%NDK_VERSION%.tar.gz
 set X86_64_FILE=play_cpp_sdk_x86_64-linux-android-%NDK_VERSION%.tar.gz
+set IOS_FILE=play_cpp_sdk_aarch64-apple-ios.tar.gz
 
 REM Set names of checksum files
 set MAC_CHECKSUM_FILE=checksums-Darwin_x86_64.txt
@@ -19,6 +20,7 @@ set LINUX_CHECKSUM_FILE=checksums-libc++_Linux_x86_64.txt
 set ANDROID_ARM64_V8A_CHECKSUM_FILE=checksums-aarch64-linux-android-%NDK_VERSION%.txt
 set ANDROID_ARMEABI_V7A_CHECKSUM_FILE=checksums-armv7-linux-androideabi-%NDK_VERSION%.txt
 set ANDROID_X86_64_CHECKSUM_FILE=checksums-x86_64-linux-android-%NDK_VERSION%.txt
+set IOS_CHECKSUM_FILE=checksums-aarch64-apple-ios.txt
 
 set MAC_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%MAC_FILE%
 set MAC_CHEKSUM_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%MAC_CHECKSUM_FILE%
@@ -32,6 +34,8 @@ set ANDROID_ARMEABI_V7A_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases
 set ANDROID_ARMEABI_V7A_CHECKSUM_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%ANDROID_ARMEABI_V7A_CHECKSUM_FILE%
 set ANDROID_X86_64_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%X86_64_FILE%
 set ANDROID_X86_64_CHECKSUM_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%ANDROID_X86_64_CHECKSUM_FILE%
+set IOS_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%IOS_FILE%
+set IOS_CHEKSUM_SRC=https://github.com/cronos-labs/play-cpp-sdk/releases/download/%PLAYCPPSDK%/%IOS_CHECKSUM_FILE%
 
 rmdir install\ /s /q
 
@@ -41,12 +45,14 @@ mkdir install\linux
 mkdir install\android\arm64-v8a
 mkdir install\android\armeabi-v7a
 mkdir install\android\x86_64
+mkdir install\ios
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Mac
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Win64
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Linux
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\arm64-v8a
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\armeabi-v7a
 mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\x86_64
+mkdir Source\ThirdParty\PlayCppSdkLibrary\Lib\iOS\arm64
 
 powershell -Command "Invoke-WebRequest %MAC_SRC% -OutFile install\mac\%MAC_FILE%"
 powershell -Command "Invoke-WebRequest %WINDOWS_SRC% -OutFile install\windows\%WINDOWS_FILE%"
@@ -54,6 +60,7 @@ powershell -Command "Invoke-WebRequest %LINUX_SRC% -OutFile install\linux\%LINUX
 powershell -Command "Invoke-WebRequest %ANDROID_ARM64_V8A_SRC% -OutFile install\android\arm64-v8a\%ARM64_V8A_FILE%"
 powershell -Command "Invoke-WebRequest %ANDROID_ARMEABI_V7A_SRC% -OutFile install\android\armeabi-v7a\%ARMEABI_V7A_FILE%"
 powershell -Command "Invoke-WebRequest %ANDROID_X86_64_SRC% -OutFile install\android\x86_64\%X86_64_FILE%"
+powershell -Command "Invoke-WebRequest %IOS_SRC% -OutFile install\ios\%IOS_FILE%"
 
 REM Check checksum
 REM echo %WINDOWSHASH% | sha256sum -c  -
@@ -65,3 +72,4 @@ tar xvf install\linux\%LINUX_FILE% -C Source\ThirdParty\PlayCppSdkLibrary\Lib\Li
 tar xvf install\android\arm64-v8a\%ARM64_V8A_FILE% -C Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\arm64-v8a --strip-components=2 sdk/lib/libplay_cpp_sdk.a
 tar xvf install\android\armeabi-v7a\%ARMEABI_V7A_FILE% -C Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\armeabi-v7a --strip-components=2 sdk/lib/libplay_cpp_sdk.a
 tar xvf install\android\x86_64\%X86_64_FILE% -C Source\ThirdParty\PlayCppSdkLibrary\Lib\Android\x86_64 --strip-components=2 sdk/lib/libplay_cpp_sdk.a
+tar xvf install\ios\%IOS_FILE% -C Source\ThirdParty\PlayCppSdkLibrary\Lib\iOS\arm64 --strip-components=2 sdk/lib/libplay_cpp_sdk.a

--- a/windows-build.bat
+++ b/windows-build.bat
@@ -1,0 +1,7 @@
+set PWD="%cd%"
+"C:\Program Files\Epic Games\UE_5.1\Engine\Build\BatchFiles\RunUAT.bat" ^
+    BuildPlugin ^
+    -Rocket ^
+    -TargetPlatforms=Win64 ^
+    -Plugin=%PWD%/CronosPlayUnreal.uplugin ^
+    -Package=%PWD%/Output


### PR DESCRIPTION
Close:
- #235

Solution:
- Use play-cpp-sdk v0.0.14-alpha
- Add windows-build.bat
- Update README

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles in Unreal Engine 4 and 5?
- [ ] Have you checked your basic code formatting and style is fine? ([using this Linter plugin](https://ue4-style-guide.readthedocs.io/en/latest/gettingstarted.html))
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the plugin version number and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
