### PR TITLE
Problem: Can not query walletconnect status (fix #257)

### DIFF
--- a/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -22,7 +22,7 @@ using namespace com::crypto::game_sdk;
 
 ::com::crypto::game_sdk::WalletconnectClient *APlayCppSdkActor::_coreClient =
     NULL;
-const APlayCppSdkActor *APlayCppSdkActor::_sdk = NULL;
+APlayCppSdkActor *APlayCppSdkActor::_sdk = NULL;
 
 class UserWalletConnectCallback : public WalletConnectCallback {
   public:
@@ -32,7 +32,7 @@ class UserWalletConnectCallback : public WalletConnectCallback {
     void onUpdated(const WalletConnectSessionInfo &sessioninfo) const;
 };
 
-const APlayCppSdkActor *APlayCppSdkActor::getInstance() { return _sdk; }
+APlayCppSdkActor *APlayCppSdkActor::getInstance() { return _sdk; }
 
 // Sets default values
 APlayCppSdkActor::APlayCppSdkActor() {
@@ -618,9 +618,12 @@ void APlayCppSdkActor::SignEip155Transaction(
     });
 }
 
-void APlayCppSdkActor::sendEvent(FWalletConnectSessionInfo info) const {
-
+void APlayCppSdkActor::sendEvent(FWalletConnectSessionInfo info) {
+    UE_LOG(LogTemp, Log, TEXT("send event: %s"),
+           *UEnum::GetValueAsString(this->_session_info.sessionstate));
     AsyncTask(ENamedThreads::GameThread, [this, info]() {
+        UE_LOG(LogTemp, Log, TEXT("Call GameThread in send event"));
+        this->_session_info = info;
         this->OnReceiveWalletconnectSessionInfoDelegate.ExecuteIfBound(info);
     });
 }

--- a/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
+++ b/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
@@ -210,7 +210,10 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
   private:
     static ::com::crypto::game_sdk::WalletconnectClient *_coreClient;
 
-    static const APlayCppSdkActor *_sdk;
+    static APlayCppSdkActor *_sdk;
+
+    // Internal session info, it will be updated every time walletconnect status changes
+    FWalletConnectSessionInfo _session_info;
 
     // Internal session result, it will be set after successfully calling
     // `EnsureSession`
@@ -249,7 +252,7 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
     FWalletconnectSessionInfoDelegate OnSetupCallbackDelegate;
 
   public:
-    static const APlayCppSdkActor *getInstance();
+    static APlayCppSdkActor *getInstance();
 
     // Sets default values for this actor's properties
     APlayCppSdkActor();
@@ -280,6 +283,14 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
         }
     }
     const int64 GetChainId() const { return _session_result.chain_id; }
+
+    UFUNCTION(BlueprintCallable,
+              meta = (DisplayName = "GetWalletConnectSessionInfo",
+                      Keywords = "PlayCppSdk"),
+              Category = "PlayCppSdk")
+    FWalletConnectSessionInfo GetWalletConnectSessionInfo() {
+        return _session_info;
+    }
 
   protected:
     // Called when the game starts or when spawned
@@ -495,7 +506,7 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
     /**
      * send wallet-connect information to unreal game thread
      */
-    void sendEvent(FWalletConnectSessionInfo) const;
+    void sendEvent(FWalletConnectSessionInfo);
 
     static void destroyCoreClient();
 


### PR DESCRIPTION
Close:
- #257

Solutions:
- Add internal _session_info and remove const
- Add public function: GetWalletConnectSessionInfo

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles in Unreal Engine 4 and 5?
- [ ] Have you checked your basic code formatting and style is fine? ([using this Linter plugin](https://ue4-style-guide.readthedocs.io/en/latest/gettingstarted.html))
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the plugin version number and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
