### PR TITLE
Problem: WalletConnectSessionInfo is not correctly constructed (fix #259)

### DIFF
--- a/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -19,21 +19,6 @@ using namespace std;
 using namespace rust;
 using namespace com::crypto::game_sdk;
 
-FWalletConnectSessionInfo::FWalletConnectSessionInfo() {
-
-    sessionstate = EWalletconnectSessionState::
-        StateDisconnected; // NOLINT : by unreal engine macro, can be ignored
-    connected = false;
-    accounts.Empty();
-    chain_id.Empty();
-    bridge.Empty();
-    key.Empty();
-    client_id.Empty();
-    client_meta.Empty();
-    peer_id.Empty();
-    peer_meta.Empty();
-    handshake_topic.Empty();
-}
 
 ::com::crypto::game_sdk::WalletconnectClient *APlayCppSdkActor::_coreClient =
     NULL;

--- a/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
+++ b/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
@@ -60,9 +60,11 @@ enum class EConnectionType : uint8 {
 /// wallet connect session info
 USTRUCT(BlueprintType)
 struct FWalletConnectSessionInfo {
-    GENERATED_BODY()
+    GENERATED_USTRUCT_BODY()
+    FWalletConnectSessionInfo()
+        : sessionstate(EWalletconnectSessionState::StateDisconnected),
+          connected(false), accounts(TArray<FString>{}), chain_id("0") {}
 
-    FWalletConnectSessionInfo();
     /// state
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayCppSdk")
     EWalletconnectSessionState sessionstate;


### PR DESCRIPTION
Close:
- #259

Solution:
- Use GENERATED_USTRUCT_BODY instead of GENERATED_BODY

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles in Unreal Engine 4 and 5?
- [ ] Have you checked your basic code formatting and style is fine? ([using this Linter plugin](https://ue4-style-guide.readthedocs.io/en/latest/gettingstarted.html))
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the plugin version number and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
