### PR TITLE
Problem: Missing StateInit and StateRestored for Walletconnect (fix #262)

### DIFF
--- a/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -337,10 +337,17 @@ void APlayCppSdkActor::EnsureSession(FEnsureSessionDelegate Out) {
                     }
                     assert(20 == newaddress.address.Num());
                     output.addresses.Add(newaddress);
+                    _session_info.accounts.Add(UUtlis::ToHex(newaddress.address));
                 }
                 assert(output.addresses.Num() ==
                        sessionresult.addresses.size());
                 output.chain_id = sessionresult.chain_id;
+
+                _session_info.sessionstate =
+                    EWalletconnectSessionState::StateRestored;
+                _session_info.connected = true;
+                _session_info.chain_id = FString::FromInt(sessionresult.chain_id);
+
                 SetWalletConnectEnsureSessionResult(output);
             } else {
                 result = FString::Printf(
@@ -427,12 +434,6 @@ void APlayCppSdkActor::SetupCallback(
 void APlayCppSdkActor::OnWalletconnectSessionInfo(
     FWalletConnectSessionInfo SessionInfo) {
     switch (SessionInfo.sessionstate) {
-    case EWalletconnectSessionState::StateConnecting:
-        break;
-    case EWalletconnectSessionState::StateConnected:
-        break;
-    case EWalletconnectSessionState::StateUpdated:
-        break;
     case EWalletconnectSessionState::StateDisconnected:
         bool success;
         this->ClearSession(success);

--- a/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
+++ b/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
@@ -44,10 +44,12 @@ DECLARE_DYNAMIC_DELEGATE_TwoParams(FCronosSignedTransactionDelegate,
 /// wallet connect session state
 UENUM(BlueprintType)
 enum class EWalletconnectSessionState : uint8 {
+    StateInit UMETA(DisplayName = "Init"),
     StateDisconnected UMETA(DisplayName = "Disconnected"),
     StateConnecting UMETA(DisplayName = "Connecting"),
     StateConnected UMETA(DisplayName = "Connected"),
-    StateUpdated UMETA(DisplayName = "Updated")
+    StateUpdated UMETA(DisplayName = "Updated"),
+    StateRestored UMETA(DisplayName = "Restored")
 };
 
 UENUM(BlueprintType)
@@ -62,7 +64,7 @@ USTRUCT(BlueprintType)
 struct FWalletConnectSessionInfo {
     GENERATED_USTRUCT_BODY()
     FWalletConnectSessionInfo()
-        : sessionstate(EWalletconnectSessionState::StateDisconnected),
+        : sessionstate(EWalletconnectSessionState::StateInit),
           connected(false), accounts(TArray<FString>{}), chain_id("0") {}
 
     /// state
@@ -212,7 +214,8 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
 
     static APlayCppSdkActor *_sdk;
 
-    // Internal session info, it will be updated every time walletconnect status changes
+    // Internal session info, it will be updated every time walletconnect status
+    // changes
     FWalletConnectSessionInfo _session_info;
 
     // Internal session result, it will be set after successfully calling


### PR DESCRIPTION
Close:
- #262 

Solution:
- Add StateInit and StateRestored
