### PR TITLE
Problem: Game Crash When disconnect walletconnect manually (fix #274)

### DIFF
--- a/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -77,6 +77,7 @@ void APlayCppSdkActor::DestroyClient() { destroyCoreClient(); }
 void APlayCppSdkActor::Destroyed() {
     Super::Destroyed();
 
+    UE_LOG(LogTemp, Log, TEXT("PlayCppActor Destroyed"));
     DestroyClient();
 
     _sdk = NULL;
@@ -400,9 +401,14 @@ void APlayCppSdkActor::ClearSession(bool &success) {
     IFileManager &FileManager = IFileManager::Get();
     success =
         FileManager.Delete(*(FPaths::ProjectSavedDir() + "sessioninfo.json"));
-    _coreClient = NULL;
+    destroyCoreClient();
     FWalletConnectEnsureSessionResult session_result;
     _session_result = session_result;
+    _session_info.sessionstate =
+        EWalletconnectSessionState::StateInit;
+    _session_info.connected = false;
+    _session_info.chain_id = FString::FromInt(0);
+
 }
 
 void APlayCppSdkActor::SetupCallback(
@@ -440,6 +446,7 @@ void APlayCppSdkActor::OnWalletconnectSessionInfo(
         this->ClearSession(success);
         if (success) {
             UE_LOG(LogTemp, Log, TEXT("sessioninfo.json was deleted"));
+
         } else {
             UE_LOG(LogTemp, Log,
                    TEXT("can not delete sessioninfo.json, please try again"));

--- a/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
+++ b/Source/CronosPlayUnreal/Private/PlayCppSdkActor.cpp
@@ -404,10 +404,7 @@ void APlayCppSdkActor::ClearSession(bool &success) {
     destroyCoreClient();
     FWalletConnectEnsureSessionResult session_result;
     _session_result = session_result;
-    _session_info.sessionstate =
-        EWalletconnectSessionState::StateInit;
-    _session_info.connected = false;
-    _session_info.chain_id = FString::FromInt(0);
+    InitWalletconnectSessionState();
 
 }
 

--- a/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
+++ b/Source/CronosPlayUnreal/Public/PlayCppSdkActor.h
@@ -239,6 +239,13 @@ class CRONOSPLAYUNREAL_API APlayCppSdkActor : public AActor {
      */
     FEnsureSessionDelegate OnEnsureSessionDelegate;
 
+    FORCEINLINE void InitWalletconnectSessionState() {
+        _session_info.sessionstate =
+            EWalletconnectSessionState::StateInit;
+        _session_info.connected = false;
+        _session_info.chain_id = FString::FromInt(0);
+    }
+
     /**
      * Used for `ConnectWalletConnect`
      */


### PR DESCRIPTION
Close:
- #274

Solutions:
- Call destroyCoreClient in ClearSession
- Set the sessionstate to StateInit

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles in Unreal Engine 4 and 5?
- [ ] Have you checked your basic code formatting and style is fine? ([using this Linter plugin](https://ue4-style-guide.readthedocs.io/en/latest/gettingstarted.html))
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the plugin version number and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-unreal-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
